### PR TITLE
fixing transaction for need posts

### DIFF
--- a/backend/app/services/join_request_service.py
+++ b/backend/app/services/join_request_service.py
@@ -226,10 +226,20 @@ class JoinRequestService:
                 transaction_service = TransactionService(self.db)
                 
                 try:
+                    # Role mapping depends on service type:
+                    # - offer: owner is provider, applicant is requester
+                    # - need:  owner is requester, applicant is provider
+                    if service.get("service_type") == "need":
+                        provider_id = str(request_doc["user_id"])
+                        requester_id = str(service["user_id"])
+                    else:
+                        provider_id = str(service["user_id"])
+                        requester_id = str(request_doc["user_id"])
+
                     transaction_data = TransactionCreate(
                         service_id=str(request_doc["service_id"]),
-                        provider_id=str(service["user_id"]),
-                        requester_id=str(request_doc["user_id"]),
+                        provider_id=provider_id,
+                        requester_id=requester_id,
                         timebank_hours=service.get("estimated_duration", 0),
                         description=f"Service exchange: {service.get('title', 'Service')}"
                     )


### PR DESCRIPTION
This PR fixes an issue where hour transactions for **Need** posts were processed in the wrong direction.

Previously, after a Need post was completed, hours were deducted from the applicant and given to the post owner.  
With this fix, hours are now deducted from the **Need post owner** and credited to the **applicant**, as intended.