### PR TITLE
Improvement in dashboard discovery with a dedicated "For You" filter

### DIFF
--- a/backend/app/api/services.py
+++ b/backend/app/api/services.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 
 from ..models.service import (
     PotentialMatchListResponse,
+    RecommendedServiceListResponse,
     ServiceCreate,
     ServiceFilters,
     ServiceListResponse,
@@ -145,6 +146,88 @@ async def get_saved_service_ids(
     )
     docs = await cursor.to_list(length=500)
     return {"service_ids": [doc["service_id"] for doc in docs]}
+
+
+@router.get("/recommendations", response_model=RecommendedServiceListResponse)
+async def get_recommended_services(
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    q: Optional[str] = None,
+    service_type: Optional[str] = None,
+    category: Optional[str] = None,
+    tags: Optional[str] = None,
+    service_status: Optional[str] = Query(ServiceStatus.ACTIVE, alias="status"),
+    city: Optional[str] = None,
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    radius: Optional[float] = Query(None, ge=0),
+    is_remote: Optional[bool] = None,
+    date_filter: Optional[str] = None,
+    current_user: UserResponse = Depends(get_current_user),
+    db=Depends(get_database),
+):
+    """Get personalized service recommendations for the current user."""
+    if (latitude is None) != (longitude is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Latitude and longitude must be provided together",
+        )
+    if radius is not None and (latitude is None or longitude is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Latitude and longitude are required when radius is provided",
+        )
+
+    service_service = ServiceService(db)
+    tag_list = tags.split(",") if tags else None
+    normalized_service_type = None if service_type in (None, "", "all") else service_type
+    normalized_status = None if service_status in (None, "", "all") else service_status
+    normalized_date_filter = None if date_filter in (None, "", "all") else date_filter
+
+    filters = ServiceFilters(
+        q=q,
+        service_type=normalized_service_type,
+        category=category,
+        tags=tag_list,
+        status=normalized_status,
+        location={
+            "latitude": latitude,
+            "longitude": longitude,
+            "address": city,
+        }
+        if latitude is not None and longitude is not None
+        else None,
+        radius=radius,
+        is_remote=is_remote,
+    )
+
+    try:
+        items, total = await service_service.get_recommended_services(
+            user_id=str(current_user.id),
+            filters=filters,
+            page=page,
+            limit=limit,
+            city=city,
+            date_filter=normalized_date_filter,
+            viewer_latitude=latitude,
+            viewer_longitude=longitude,
+        )
+        return RecommendedServiceListResponse(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error fetching recommendations: {str(e)}",
+        )
 
 
 @router.get("/{service_id}/potential-matches", response_model=PotentialMatchListResponse)

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -219,6 +219,26 @@ class PotentialMatchListResponse(BaseModel):
         json_encoders = {ObjectId: str}
 
 
+class RecommendedServiceItem(BaseModel):
+    service: ServiceResponse
+    reason: str = Field(..., min_length=1, max_length=160)
+    score: float = Field(..., ge=0)
+    matched_interests: List[str] = Field(default_factory=list)
+
+    class Config:
+        json_encoders = {ObjectId: str}
+
+
+class RecommendedServiceListResponse(BaseModel):
+    items: List[RecommendedServiceItem]
+    total: int
+    page: int
+    limit: int
+
+    class Config:
+        json_encoders = {ObjectId: str}
+
+
 class ServiceFilters(BaseModel):
     q: Optional[str] = None
     service_type: Optional[ServiceType] = None

--- a/backend/app/services/service_service.py
+++ b/backend/app/services/service_service.py
@@ -1,11 +1,12 @@
 from typing import List, Tuple, Optional, Set
-from datetime import datetime
+from datetime import datetime, timedelta
 import math
 import re
 from bson import ObjectId
 
 from ..models.service import (
     PotentialMatchItem,
+    RecommendedServiceItem,
     ServiceCreate,
     ServiceFilters,
     ServiceResponse,
@@ -239,10 +240,207 @@ class ServiceService:
         best_reason, best_score = max(reason_scores, key=lambda item: item[1])
         return best_reason if best_score > 0 else "Potential match"
 
+    @staticmethod
+    def _normalize_text_value(value: Optional[str]) -> str:
+        return str(value or "").strip().lower()
+
+    def _build_tag_filter_conditions(self, tags: List[str]) -> List[dict]:
+        return [
+            {"tags": {"$in": tags}},
+            {"tags.label": {"$in": tags}},
+            {"tags.entityId": {"$in": tags}},
+        ]
+
+    def _build_search_conditions(self, query_text: str) -> List[dict]:
+        escaped = re.escape(query_text)
+        return [
+            {"title": {"$regex": escaped, "$options": "i"}},
+            {"description": {"$regex": escaped, "$options": "i"}},
+            {"category": {"$regex": escaped, "$options": "i"}},
+            {"tags.label": {"$regex": escaped, "$options": "i"}},
+            {"tags.entityId": {"$regex": escaped, "$options": "i"}},
+            {"location.address": {"$regex": escaped, "$options": "i"}},
+        ]
+
+    def _build_recommendation_query(
+        self,
+        filters: ServiceFilters,
+        city: Optional[str] = None,
+        date_filter: Optional[str] = None,
+    ) -> dict:
+        clauses: List[dict] = []
+
+        if filters.service_type:
+            clauses.append({"service_type": filters.service_type})
+        if filters.category:
+            clauses.append({"category": filters.category})
+        if filters.tags:
+            clauses.append({"$or": self._build_tag_filter_conditions(filters.tags)})
+        if filters.status:
+            clauses.append({"status": filters.status})
+        if filters.user_id:
+            user_id_obj = (
+                ObjectId(filters.user_id)
+                if isinstance(filters.user_id, str)
+                else filters.user_id
+            )
+            clauses.append({"user_id": user_id_obj})
+        if filters.is_remote is not None:
+            clauses.append({"is_remote": filters.is_remote})
+        if filters.q:
+            clauses.append({"$or": self._build_search_conditions(filters.q)})
+
+        normalized_city = self._normalize_text_value(city)
+        if normalized_city:
+            clauses.append(
+                {"location.address": {"$regex": re.escape(normalized_city), "$options": "i"}}
+            )
+
+        if date_filter == "open_availability":
+            clauses.append({"scheduling_type": "open"})
+        elif date_filter == "recurring":
+            clauses.append({"scheduling_type": "recurring"})
+        elif date_filter in {"today", "tomorrow", "this_week"}:
+            now = datetime.utcnow()
+            today_str = now.strftime("%Y-%m-%d")
+            tomorrow_str = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+            if date_filter == "tomorrow":
+                tomorrow_str = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+            clauses.append({"scheduling_type": "specific"})
+            if date_filter == "today":
+                clauses.append({"specific_date": today_str})
+            elif date_filter == "tomorrow":
+                clauses.append({"specific_date": tomorrow_str})
+            else:
+                days_since_sunday = (now.weekday() + 1) % 7
+                start_of_week = now - timedelta(days=days_since_sunday)
+                end_of_week = start_of_week + timedelta(days=6)
+                clauses.append(
+                    {
+                        "specific_date": {
+                            "$gte": start_of_week.strftime("%Y-%m-%d"),
+                            "$lte": end_of_week.strftime("%Y-%m-%d"),
+                        }
+                    }
+                )
+
+        if not clauses:
+            return {}
+        if len(clauses) == 1:
+            return clauses[0]
+        return {"$and": clauses}
+
+    def _build_service_content_blob(self, service_like: dict) -> str:
+        location = service_like.get("location") or {}
+        tag_labels = sorted(self._get_tag_labels(service_like.get("tags")))
+        return self._normalize_text_value(
+            " ".join(
+                str(part)
+                for part in [
+                    service_like.get("title"),
+                    service_like.get("description"),
+                    service_like.get("category"),
+                    location.get("address"),
+                    *tag_labels,
+                ]
+                if part
+            )
+        )
+
+    def _build_similarity_profile(self, service_like: dict) -> Tuple[Set[str], Set[str]]:
+        tag_labels = self._get_tag_labels(service_like.get("tags"))
+        location = service_like.get("location") or {}
+        tokens = self._tokenize_text(
+            service_like.get("title"),
+            service_like.get("description"),
+            service_like.get("category"),
+            location.get("address"),
+            *tag_labels,
+        )
+        return tag_labels, tokens
+
+    def _max_profile_similarity(
+        self,
+        candidate_profile: Tuple[Set[str], Set[str]],
+        reference_profiles: List[Tuple[Set[str], Set[str]]],
+    ) -> float:
+        candidate_tags, candidate_tokens = candidate_profile
+        max_similarity = 0.0
+
+        for reference_tags, reference_tokens in reference_profiles:
+            max_similarity = max(
+                max_similarity,
+                self._jaccard_similarity(candidate_tags, reference_tags),
+                self._jaccard_similarity(candidate_tokens, reference_tokens),
+            )
+
+        return max_similarity
+
+    @staticmethod
+    def _format_distance_label(distance_value: float) -> str:
+        if distance_value < 1:
+            return f"{round(distance_value * 1000)} m"
+        return f"{round(distance_value)} km"
+
+    def _resolve_dashboard_recommendation_reason(
+        self,
+        matched_interests: List[str],
+        saved_similarity: float,
+        transaction_similarity: float,
+        distance_value: Optional[float],
+        city: Optional[str],
+        search_query: Optional[str],
+        service_doc: dict,
+    ) -> str:
+        if saved_similarity >= 0.2:
+            return "Because it's similar to services you saved"
+        if transaction_similarity >= 0.2:
+            return "Because it matches your previous exchanges"
+        if distance_value is not None and distance_value <= 10:
+            return f"Because it's only {self._format_distance_label(distance_value)} away"
+        if matched_interests:
+            return f"Because it matches your interest in {matched_interests[0]}"
+        if (search_query or "").strip():
+            return f'Because it fits "{search_query.strip()}"'
+        normalized_city = self._normalize_text_value(city)
+        if normalized_city:
+            return f"Because it's active in {normalized_city}"
+        if service_doc.get("is_remote"):
+            return "Because it works well remotely"
+        return "Because it's a fresh active post"
+
     async def _get_saved_service_ids(self, user_id: str) -> Set[str]:
         cursor = self.saved_services_collection.find({"user_id": user_id})
         saved_docs = await cursor.to_list(length=500)
         return {str(doc["service_id"]) for doc in saved_docs if doc.get("service_id")}
+
+    async def _get_services_by_ids(self, service_ids: Set[str]) -> List[dict]:
+        object_ids = []
+        for service_id in service_ids:
+            normalized_id = self._normalize_object_id(service_id)
+            if isinstance(normalized_id, ObjectId):
+                object_ids.append(normalized_id)
+
+        if not object_ids:
+            return []
+
+        cursor = self.services_collection.find({"_id": {"$in": object_ids}})
+        docs = await cursor.to_list(length=len(object_ids))
+        return [self._normalize_service_doc(doc) for doc in docs]
+
+    async def _get_user_transactions_for_recommendations(self, user_id: str) -> List[dict]:
+        query = {"$or": [{"provider_id": user_id}, {"requester_id": user_id}]}
+        normalized_user_id = self._normalize_object_id(user_id)
+        if isinstance(normalized_user_id, ObjectId):
+            query["$or"].extend(
+                [
+                    {"provider_id": normalized_user_id},
+                    {"requester_id": normalized_user_id},
+                ]
+            )
+
+        cursor = self.transactions_collection.find(query).sort("created_at", -1)
+        return await cursor.to_list(length=500)
 
     async def _get_applied_service_ids(self, user_id: str) -> Set[str]:
         user_id_filter = {"$or": [{"user_id": user_id}]}
@@ -493,6 +691,205 @@ class ServiceService:
         total = len(potential_matches)
         return potential_matches[:limit], total
 
+    async def get_recommended_services(
+        self,
+        user_id: str,
+        filters: Optional[ServiceFilters] = None,
+        page: int = 1,
+        limit: int = 20,
+        city: Optional[str] = None,
+        date_filter: Optional[str] = None,
+        viewer_latitude: Optional[float] = None,
+        viewer_longitude: Optional[float] = None,
+    ) -> Tuple[List[RecommendedServiceItem], int]:
+        filters = filters or ServiceFilters()
+        viewer_position = (
+            (viewer_latitude, viewer_longitude)
+            if viewer_latitude is not None and viewer_longitude is not None
+            else None
+        )
+
+        user_doc = await self.users_collection.find_one(
+            {"_id": self._normalize_object_id(user_id)}
+        )
+        normalized_interests = [
+            {
+                "label": interest,
+                "normalized": self._normalize_text_value(interest),
+            }
+            for interest in (user_doc or {}).get("interests", []) or []
+            if isinstance(interest, str) and self._normalize_text_value(interest)
+        ]
+
+        saved_service_ids = await self._get_saved_service_ids(user_id)
+        saved_service_docs = await self._get_services_by_ids(saved_service_ids)
+        saved_profiles = [
+            self._build_similarity_profile(service_doc)
+            for service_doc in saved_service_docs
+        ]
+
+        transaction_docs = await self._get_user_transactions_for_recommendations(user_id)
+        transacted_service_ids = {
+            str(doc["service_id"])
+            for doc in transaction_docs
+            if doc.get("service_id")
+        }
+        transaction_service_docs = await self._get_services_by_ids(transacted_service_ids)
+        service_lookup = {
+            str(service_doc.get("_id")): service_doc
+            for service_doc in [*saved_service_docs, *transaction_service_docs]
+        }
+
+        transaction_profiles: List[Tuple[Set[str], Set[str]]] = []
+        for transaction_doc in transaction_docs:
+            service_doc = service_lookup.get(str(transaction_doc.get("service_id")))
+            if service_doc:
+                transaction_profiles.append(
+                    self._build_similarity_profile(service_doc)
+                )
+                continue
+
+            fallback_service = (
+                transaction_doc.get("service")
+                if isinstance(transaction_doc.get("service"), dict)
+                else {}
+            )
+            profile = self._build_similarity_profile(
+                {
+                    "title": fallback_service.get("title"),
+                    "description": fallback_service.get("description"),
+                    "category": fallback_service.get("category"),
+                    "location": fallback_service.get("location"),
+                    "tags": fallback_service.get("tags"),
+                }
+            )
+            if profile[0] or profile[1]:
+                transaction_profiles.append(profile)
+
+        query = self._build_recommendation_query(
+            filters=filters,
+            city=city,
+            date_filter=date_filter,
+        )
+        cursor = self.services_collection.find(query).sort("created_at", -1)
+
+        normalized_city = self._normalize_text_value(city)
+        search_text = self._normalize_text_value(filters.q)
+        recommended_items: List[RecommendedServiceItem] = []
+
+        async for raw_service_doc in cursor:
+            service_doc = self._normalize_service_doc(raw_service_doc)
+            candidate_id = str(service_doc.get("_id"))
+            if not candidate_id:
+                continue
+            if str(service_doc.get("user_id")) == str(user_id):
+                continue
+            if candidate_id in saved_service_ids or candidate_id in transacted_service_ids:
+                continue
+
+            location = service_doc.get("location") or {}
+            raw_distance_value: Optional[float] = None
+            if (
+                viewer_position
+                and location.get("latitude") is not None
+                and location.get("longitude") is not None
+            ):
+                raw_distance_value = self.calculate_distance(
+                    viewer_position[0],
+                    viewer_position[1],
+                    float(location["latitude"]),
+                    float(location["longitude"]),
+                )
+
+            if filters.radius is not None and viewer_position:
+                if raw_distance_value is None or raw_distance_value > filters.radius:
+                    continue
+
+            candidate_profile = self._build_similarity_profile(service_doc)
+            content_blob = self._build_service_content_blob(service_doc)
+
+            matched_interests = [
+                interest["label"]
+                for interest in normalized_interests
+                if interest["normalized"] in candidate_profile[0]
+                or interest["normalized"] in content_blob
+            ]
+            saved_similarity = self._max_profile_similarity(
+                candidate_profile,
+                saved_profiles,
+            )
+            transaction_similarity = self._max_profile_similarity(
+                candidate_profile,
+                transaction_profiles,
+            )
+
+            address_text = self._normalize_text_value(location.get("address"))
+            city_match = bool(normalized_city and normalized_city in address_text)
+            search_match = bool(search_text and search_text in content_blob)
+            distance_value = (
+                None if service_doc.get("is_remote") else raw_distance_value
+            )
+            distance_boost = (
+                0.2
+                if distance_value is None and service_doc.get("is_remote")
+                else 1.6
+                if distance_value is not None and distance_value <= 3
+                else 1.15
+                if distance_value is not None and distance_value <= 10
+                else 0.6
+                if distance_value is not None and distance_value <= 25
+                else 0.0
+            )
+
+            has_recommendation_signal = (
+                saved_similarity >= 0.2
+                or transaction_similarity >= 0.2
+                or len(matched_interests) > 0
+                or (distance_value is not None and distance_value <= 25)
+                or search_match
+                or city_match
+            )
+
+            if not has_recommendation_signal:
+                continue
+
+            score = (
+                len(matched_interests) * 2.4
+                + saved_similarity * 3.4
+                + transaction_similarity * 3.0
+                + distance_boost
+                + (0.8 if city_match else 0.0)
+                + (0.8 if search_match else 0.0)
+                + self._calculate_recency_score(service_doc) * 0.5
+            )
+
+            recommended_items.append(
+                RecommendedServiceItem(
+                    service=ServiceResponse(**service_doc),
+                    reason=self._resolve_dashboard_recommendation_reason(
+                        matched_interests=matched_interests,
+                        saved_similarity=saved_similarity,
+                        transaction_similarity=transaction_similarity,
+                        distance_value=distance_value,
+                        city=city,
+                        search_query=filters.q,
+                        service_doc=service_doc,
+                    ),
+                    score=round(score, 4),
+                    matched_interests=matched_interests,
+                )
+            )
+
+        recommended_items.sort(
+            key=lambda item: (item.score, item.service.created_at),
+            reverse=True,
+        )
+
+        total = len(recommended_items)
+        start = max((page - 1) * limit, 0)
+        end = start + limit
+        return recommended_items[start:end], total
+
     async def create_service(self, service_data: ServiceCreate, user_id: str) -> ServiceResponse:
         """Create a new service"""
         try:
@@ -566,13 +963,7 @@ class ServiceService:
             if filters.category:
                 query["category"] = filters.category
             if filters.tags:
-                # Tags are now dicts with "label" field, so we need to match against labels
-                # Support both old string tags and new entity tags
-                tag_labels = filters.tags
-                query["$or"] = [
-                    {"tags": {"$in": tag_labels}},  # Match old string format
-                    {"tags.label": {"$in": tag_labels}}  # Match new entity format
-                ]
+                query["$or"] = self._build_tag_filter_conditions(filters.tags)
             if filters.status:
                 query["status"] = filters.status
             if filters.user_id:
@@ -620,12 +1011,7 @@ class ServiceService:
                 if filters.category:
                     match_stage["category"] = filters.category
                 if filters.tags:
-                    # Tags are now dicts with "label" field, so we need to match against labels
-                    tag_labels = filters.tags
-                    match_stage["$or"] = [
-                        {"tags": {"$in": tag_labels}},  # Match old string format
-                        {"tags.label": {"$in": tag_labels}}  # Match new entity format
-                    ]
+                    match_stage["$or"] = self._build_tag_filter_conditions(filters.tags)
                 if filters.status:
                     match_stage["status"] = filters.status
                 if filters.user_id:

--- a/frontend/src/components/ui/DashboardFilterBar.tsx
+++ b/frontend/src/components/ui/DashboardFilterBar.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { Button, Flex, Popover, Text, Separator } from "@radix-ui/themes";
-import { ChevronDownIcon, Cross2Icon } from "@radix-ui/react-icons";
+import {
+  ChevronDownIcon,
+  Cross2Icon,
+  HeartFilledIcon,
+} from "@radix-ui/react-icons";
 import { InterestChip } from "./InterestChip";
 import { TagEntity } from "@/types";
 import {
@@ -14,6 +18,7 @@ import { getCityOptions } from "@/constants/turkishCities";
 // ---------------------------------------------------------------------------
 
 export interface DashboardFilters {
+  forYouOnly: boolean;
   serviceType: ServiceTypeFilter;
   status: string;
   selectedTags: string[];
@@ -30,6 +35,7 @@ export interface DashboardFilters {
 }
 
 export const defaultDashboardFilters: DashboardFilters = {
+  forYouOnly: false,
   serviceType: "all",
   status: "active",
   selectedTags: [],
@@ -82,6 +88,7 @@ const DATE_OPTIONS = [
 
 function isDefault(filters: DashboardFilters): boolean {
   return (
+    filters.forYouOnly === defaultDashboardFilters.forYouOnly &&
     filters.serviceType === defaultDashboardFilters.serviceType &&
     filters.status === defaultDashboardFilters.status &&
     filters.selectedTags.length === 0 &&
@@ -214,7 +221,29 @@ export function DashboardFilterBar({
     onFiltersChange({ ...filters, ...partial });
 
   return (
-    <div className="filter-bar-scroll flex items-center gap-2 pt-2 overflow-x-auto col-span-2">
+    <div className="filter-bar-scroll flex w-full flex-wrap items-center gap-2 pt-2">
+      <button
+        className={`
+          filter-pill inline-flex items-center gap-1.5 whitespace-nowrap
+          rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 hover:shadow-sm
+          ${
+            filters.forYouOnly
+              ? "border-current font-semibold filter-pill-active text-[var(--teal-11)]"
+              : "border-[var(--gray-6)] text-[var(--gray-11)]"
+          }
+        `}
+        onClick={() => update({ forYouOnly: !filters.forYouOnly })}
+      >
+        <HeartFilledIcon
+          className={`h-3.5 w-3.5 shrink-0 transition-transform duration-200 ${
+            filters.forYouOnly
+              ? "scale-110 text-rose-400"
+              : "text-rose-300"
+          }`}
+        />
+        For you
+      </button>
+
       {/* Service Type */}
       <FilterPill
         label={pillLabel("Type", filters.serviceType, SERVICE_TYPE_OPTIONS)}

--- a/frontend/src/components/ui/OfferListingCard.tsx
+++ b/frontend/src/components/ui/OfferListingCard.tsx
@@ -12,7 +12,17 @@ import { usersApi, ratingsApi } from "@/services/api";
 import { StatusBadge } from "./StatusBadge";
 import { CustomBadge, getHighestPriorityBadge } from "./BadgeDisplay";
 
-export function OfferListingCard({ service }: { service: Service }) {
+interface OfferListingCardProps {
+  service: Service;
+  recommendationReason?: string;
+  isRecommended?: boolean;
+}
+
+export function OfferListingCard({
+  service,
+  recommendationReason,
+  isRecommended = false,
+}: OfferListingCardProps) {
   const navigate = useNavigate();
   const [user, setUser] = useState<any>(null);
   const [badgeSummary, setBadgeSummary] = useState<BadgeSummary | null>(null);
@@ -59,6 +69,8 @@ export function OfferListingCard({ service }: { service: Service }) {
     return `${hours}h`;
   };
 
+  const ownerLabel = user?.full_name || `@${user?.username || ""}`;
+
   const formatDate = (dateString: string) => {
     const now = new Date();
     const commentDate = new Date(dateString);
@@ -83,41 +95,67 @@ export function OfferListingCard({ service }: { service: Service }) {
     }
   };
 
+  const ownerMeta = (
+    <Flex
+      align="center"
+      gap="1"
+      className={`text-sm opacity-70 ${isRecommended ? "shrink-0 whitespace-nowrap" : ""}`}
+    >
+      {badgeSummary?.last_earned_badge && (
+        <CustomBadge badge={badgeSummary.last_earned_badge} size={14} />
+      )}
+      {averageRating != null && (
+        <Flex align="center" gap="1">
+          <StarFilledIcon className="w-3 h-3 text-yellow-500" />
+          <Text size="1">{averageRating.toFixed(1)}</Text>
+        </Flex>
+      )}
+      <Text
+        size="1"
+        className={isRecommended ? "whitespace-nowrap" : "max-w-[100px] truncate"}
+      >
+        {ownerLabel}
+      </Text>
+    </Flex>
+  );
+
   return (
     <Card
       size="2"
-      className="hover-card flex flex-col h-full gap-2 overflow-hidden"
+      className={`hover-card flex flex-col h-full gap-2 overflow-hidden ${
+        isRecommended ? "recommended-listing-card" : ""
+      }`}
       onClick={handleCardClick}
     >
       {/* Header with status badges (left) and user info (right) */}
-      <div className="flex gap-2 justify-between items-center">
-        <Flex align="center" gap="1">
-          <StatusBadge status={service.status} size="1" variant="soft" />
-          <Badge
-            color={service?.service_type === "offer" ? "orange" : "blue"}
-            variant="soft"
-          >
-            {service?.service_type === "offer" ? "OFFER" : "NEED"}
-          </Badge>
-        </Flex>
-        <Flex align="center" gap="1" className="text-sm opacity-70">
-          {badgeSummary?.last_earned_badge && (
-            <CustomBadge badge={badgeSummary.last_earned_badge} size={14} />
-          )}
-          {averageRating != null && (
-            <Flex align="center" gap="1">
-              <StarFilledIcon className="w-3 h-3 text-yellow-500" />
-              <Text size="1">{averageRating.toFixed(1)}</Text>
-            </Flex>
-          )}
-          <Text size="1" className="max-w-[100px] truncate">
-            {user?.full_name || `@${user?.username || ""}`}
+      <div className={`flex gap-2 ${isRecommended ? "flex-col" : "items-center justify-between"}`}>
+        {isRecommended && (
+          <Text size="1" className="recommended-listing-label">
+            Recommended
           </Text>
-        </Flex>
+        )}
+        <div className="flex items-center justify-between gap-2">
+          <Flex align="center" gap="1" wrap="wrap" className="min-w-0">
+            <StatusBadge status={service.status} size="1" variant="soft" />
+            <Badge
+              color={service?.service_type === "offer" ? "orange" : "blue"}
+              variant="soft"
+            >
+              {service?.service_type === "offer" ? "OFFER" : "NEED"}
+            </Badge>
+          </Flex>
+          {ownerMeta}
+        </div>
       </div>
       <h3 className="capitalize text-xl font-bold leading-tight my-1">
         {service.title}
       </h3>
+
+      {recommendationReason && (
+        <Text size="2" className="recommended-listing-reason">
+          {recommendationReason}
+        </Text>
+      )}
 
       {/* Details row */}
       <Flex align="center" gap="1" className="text-sm">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -291,6 +291,8 @@ button {
 }
 
 .filter-bar-scroll {
+    width: 100%;
+    row-gap: 0.75rem;
     scrollbar-width: none;          /* Firefox */
     -ms-overflow-style: none;       /* IE/Edge */
 }
@@ -311,3 +313,34 @@ button {
     background-color: var(--gray-3);
 }
 
+.recommended-listing-card {
+    border: 1px solid rgba(176, 214, 87, 0.5) !important;
+    background:
+        radial-gradient(circle at top right, rgba(196, 255, 112, 0.66), transparent 24%),
+        radial-gradient(circle at left bottom, rgba(255, 224, 120, 0.15), transparent 34%),
+        linear-gradient(135deg, rgba(252, 255, 240, 0.99), rgba(243, 251, 214, 0.98) 62%, rgba(255, 251, 236, 0.98)) !important;
+    box-shadow:
+        0 16px 38px rgba(151, 181, 76, 0.12),
+        0 8px 18px rgba(251, 191, 36, 0.08);
+}
+
+.recommended-listing-card:hover {
+    border-color: rgba(176, 214, 87, 0.78) !important;
+    box-shadow:
+        0 22px 46px rgba(151, 181, 76, 0.18),
+        0 12px 24px rgba(251, 191, 36, 0.12);
+}
+
+.recommended-listing-label {
+    color: #8aa02a;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.recommended-listing-reason {
+    color: #5d6d40;
+    font-weight: 500;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -10,33 +10,33 @@ import {
   defaultDashboardFilters,
   type DashboardFilters,
 } from "@/components/ui/DashboardFilterBar";
-import { servicesApi, forumApi } from "@/services/api";
+import { servicesApi, forumApi, usersApi } from "@/services/api";
 import {
+  Box,
   Button,
+  Card,
   Dialog,
+  Flex,
   Heading,
   Text,
-  Flex,
-  Card,
-  Box,
+  Callout,
 } from "@radix-ui/themes";
 import {
-  HandIcon,
-  SunIcon,
   Crosshair1Icon,
+  HandIcon,
   PlusIcon,
+  SunIcon,
 } from "@radix-ui/react-icons";
-import { usersApi } from "@/services/api";
-import { Callout } from "@radix-ui/themes";
 import { OfferNeedForm } from "@/components/forms/OfferNeedForm";
 import { useFilters } from "@/contexts/FilterContext";
+import { useUser } from "@/contexts/UserContext";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Service, TagEntity } from "@/types";
-import { ForumEvent } from "@/types";
+import { ForumEvent, RecommendedServiceItem, Service, TagEntity } from "@/types";
 
 export function Dashboard() {
+  const { currentUserId } = useUser();
   const [services, setServices] = useState<Service[]>([]);
   const [filteredServices, setFilteredServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
@@ -59,41 +59,94 @@ export function Dashboard() {
   });
   const [forumEvents, setForumEvents] = useState<ForumEvent[]>([]);
 
-  // Derive unique tags from loaded services for the filter bar
   const availableTags = useMemo<TagEntity[]>(() => {
     const seen = new Set<string>();
     const tags: TagEntity[] = [];
-    for (const s of services) {
-      for (const t of s.tags ?? []) {
-        if (typeof t === "string") continue;
-        const id = t.entityId || t.label;
+    for (const service of services) {
+      for (const tag of service.tags ?? []) {
+        if (typeof tag === "string") continue;
+        const id = tag.entityId || tag.label;
         if (!seen.has(id)) {
           seen.add(id);
-          tags.push(t);
+          tags.push(tag);
         }
       }
     }
-    return tags.sort((a, b) => a.label.localeCompare(b.label));
+    return tags.sort((left, right) => left.label.localeCompare(right.label));
   }, [services]);
 
-  // Sync header city → dashFilters
+  const remoteRecommendationFilter =
+    dashFilters.remoteFilter === "remote"
+      ? true
+      : dashFilters.remoteFilter === "in_person"
+        ? false
+        : undefined;
+
+  const { data: recommendedServicesData, isFetching: isRecommendationsLoading } =
+    useQuery({
+      queryKey: [
+        "dashboard-recommendations",
+        currentUserId,
+        searchQuery,
+        selectedCity,
+        dashFilters.serviceType,
+        dashFilters.status,
+        dashFilters.selectedTags,
+        dashFilters.remoteFilter,
+        dashFilters.distance,
+        dashFilters.dateFilter,
+        userPosition?.[0],
+        userPosition?.[1],
+      ],
+      queryFn: () =>
+        servicesApi
+          .getRecommendedServices({
+            page: 1,
+            limit: 100,
+            q: searchQuery?.trim() || undefined,
+            service_type:
+              dashFilters.serviceType !== "all"
+                ? dashFilters.serviceType
+                : undefined,
+            status:
+              dashFilters.status !== "all" ? dashFilters.status : undefined,
+            tags:
+              dashFilters.selectedTags.length > 0
+                ? dashFilters.selectedTags.join(",")
+                : undefined,
+            city:
+              selectedCity && selectedCity !== "all" ? selectedCity : undefined,
+            latitude: userPosition?.[0],
+            longitude: userPosition?.[1],
+            radius:
+              typeof dashFilters.distance === "number"
+                ? dashFilters.distance
+                : undefined,
+            is_remote: remoteRecommendationFilter,
+            date_filter:
+              dashFilters.dateFilter !== "all"
+                ? dashFilters.dateFilter
+                : undefined,
+          })
+          .then((res) => res.data),
+      enabled: !!currentUserId && dashFilters.forYouOnly,
+      retry: false,
+    });
+
   useEffect(() => {
     setDashFilters((prev) =>
       prev.city !== selectedCity ? { ...prev, city: selectedCity } : prev,
     );
   }, [selectedCity]);
 
-  // Keep map filters in sync with dashboard filter bar
   const handleDashFiltersChange = useCallback(
     (next: DashboardFilters) => {
       setDashFilters(next);
-      // Sync overlapping fields to map
       setMapFilters((prev) => ({
         ...prev,
         serviceType: next.serviceType,
         distance: next.distance,
       }));
-      // Sync city to header/context
       setSelectedCity(next.city);
     },
     [setSelectedCity],
@@ -103,23 +156,28 @@ export function Dashboard() {
     const onSuccess = (pos: GeolocationPosition) => {
       setUserPosition([pos.coords.latitude, pos.coords.longitude]);
     };
+
     const ipFallback = () => {
       fetch("https://ipapi.co/json/")
-        .then((r) => {
-          if (!r.ok) throw new Error("IP lookup failed");
-          return r.json();
+        .then((response) => {
+          if (!response.ok) throw new Error("IP lookup failed");
+          return response.json();
         })
-        .then((d) => {
-          if (d.latitude && d.longitude)
-            setUserPosition([d.latitude, d.longitude]);
-          else setUserPosition([41.0082, 28.9784]);
+        .then((data) => {
+          if (data.latitude && data.longitude) {
+            setUserPosition([data.latitude, data.longitude]);
+          } else {
+            setUserPosition([41.0082, 28.9784]);
+          }
         })
         .catch(() => setUserPosition([41.0082, 28.9784]));
     };
+
     if (!navigator.geolocation) {
       ipFallback();
       return;
     }
+
     navigator.geolocation.getCurrentPosition(onSuccess, () => ipFallback(), {
       enableHighAccuracy: false,
       timeout: 10000,
@@ -130,21 +188,24 @@ export function Dashboard() {
   useEffect(() => {
     forumApi
       .getEvents({ has_location: true, limit: 200 })
-      .then((r) => setForumEvents(r.data.events || []))
+      .then((response) => setForumEvents(response.data.events || []))
       .catch(() => setForumEvents([]));
   }, []);
 
-  const fetchServices = async (searchQ?: string) => {
+  const fetchServices = async (searchValue?: string) => {
     const isInitialLoad = services.length === 0 && loading;
+
     try {
       if (isInitialLoad) {
         setLoading(true);
       } else {
         setIsSearching(true);
       }
+
       const response = await servicesApi.getServices({
-        q: searchQ?.trim() || undefined,
+        q: searchValue?.trim() || undefined,
       });
+
       setServices(response.data.services || []);
       setFilteredServices(response.data.services || []);
     } catch (error) {
@@ -161,23 +222,22 @@ export function Dashboard() {
     fetchServices();
   }, []);
 
-  // Re-fetch when search query changes (debounced)
   useEffect(() => {
     if (!searchQuery) {
       fetchServices();
       return;
     }
+
     const timeout = setTimeout(() => {
       fetchServices(searchQuery);
     }, 300);
+
     return () => clearTimeout(timeout);
   }, [searchQuery]);
 
-  // Filter services based on city and tag URL param (search is now server-side)
   useEffect(() => {
     let filtered = services;
 
-    // Filter by tag (URL param): match entityId or decoded label
     if (tagParam && tagParam.trim()) {
       const decoded = decodeURIComponent(tagParam.trim());
       const isEntityId = /^Q\d+$/i.test(decoded);
@@ -190,7 +250,6 @@ export function Dashboard() {
       );
     }
 
-    // Filter by city
     if (selectedCity && selectedCity !== "all") {
       filtered = filtered.filter((service) => {
         const address = service.location.address?.toLowerCase() || "";
@@ -201,61 +260,66 @@ export function Dashboard() {
     setFilteredServices(filtered);
   }, [services, selectedCity, tagParam]);
 
-  const displayedServices = useMemo(() => {
+  const eligibleServices = useMemo(() => {
     let list = applyMapFilters(filteredServices, mapFilters, userPosition);
 
-    // Status filter
     if (dashFilters.status !== "all") {
-      list = list.filter((s) => s.status === dashFilters.status);
+      list = list.filter((service) => service.status === dashFilters.status);
     }
 
-    // Remote / in-person filter
     if (dashFilters.remoteFilter === "remote") {
-      list = list.filter((s) => s.is_remote === true);
+      list = list.filter((service) => service.is_remote === true);
     } else if (dashFilters.remoteFilter === "in_person") {
-      list = list.filter((s) => s.is_remote === false);
+      list = list.filter((service) => service.is_remote === false);
     }
 
-    // Tags filter (OR: service must have at least one of the selected tags)
     if (dashFilters.selectedTags.length > 0) {
-      list = list.filter((s) =>
+      list = list.filter((service) =>
         dashFilters.selectedTags.some((tagId) =>
-          (s.tags ?? []).some((t) => {
-            if (typeof t === "string") return t === tagId;
-            return t.entityId === tagId || t.label === tagId;
+          (service.tags ?? []).some((tag) => {
+            if (typeof tag === "string") return tag === tagId;
+            return tag.entityId === tagId || tag.label === tagId;
           }),
         ),
       );
     }
 
-    // Availability / scheduling filter
     if (dashFilters.dateFilter !== "all") {
       if (dashFilters.dateFilter === "open_availability") {
-        list = list.filter((s) => s.scheduling_type === "open");
+        list = list.filter((service) => service.scheduling_type === "open");
       } else if (dashFilters.dateFilter === "recurring") {
-        list = list.filter((s) => s.scheduling_type === "recurring");
+        list = list.filter((service) => service.scheduling_type === "recurring");
       } else {
-        // specific_date based: today / tomorrow / this_week
         const now = new Date();
         const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
         const tomorrow = new Date(now);
         tomorrow.setDate(now.getDate() + 1);
         const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
 
-        list = list.filter((s) => {
-          if (s.scheduling_type !== "specific" || !s.specific_date) return false;
-          const dateStr = s.specific_date.slice(0, 10); // "YYYY-MM-DD"
+        list = list.filter((service) => {
+          if (
+            service.scheduling_type !== "specific" ||
+            !service.specific_date
+          ) {
+            return false;
+          }
+
+          const dateStr = service.specific_date.slice(0, 10);
           if (dashFilters.dateFilter === "today") return dateStr === todayStr;
-          if (dashFilters.dateFilter === "tomorrow") return dateStr === tomorrowStr;
-          // this_week: Mon–Sun of current week
+          if (dashFilters.dateFilter === "tomorrow") {
+            return dateStr === tomorrowStr;
+          }
+
           const startOfWeek = new Date(now);
           startOfWeek.setDate(now.getDate() - now.getDay());
           startOfWeek.setHours(0, 0, 0, 0);
+
           const endOfWeek = new Date(startOfWeek);
           endOfWeek.setDate(startOfWeek.getDate() + 6);
           endOfWeek.setHours(23, 59, 59, 999);
-          const d = new Date(s.specific_date);
-          return d >= startOfWeek && d <= endOfWeek;
+
+          const serviceDate = new Date(service.specific_date);
+          return serviceDate >= startOfWeek && serviceDate <= endOfWeek;
         });
       }
     }
@@ -263,80 +327,109 @@ export function Dashboard() {
     return list;
   }, [filteredServices, mapFilters, userPosition, dashFilters]);
 
+  const recommendedServices: RecommendedServiceItem[] =
+    recommendedServicesData?.items ?? [];
+
+  const recommendationReasonMap = useMemo(
+    () =>
+      new Map(
+        recommendedServices.map((item) => [item.service._id, item.reason] as const),
+      ),
+    [recommendedServices],
+  );
+
+  const displayedServices = useMemo(
+    () =>
+      dashFilters.forYouOnly
+        ? applyMapFilters(
+            recommendedServices.map((item) => item.service),
+            mapFilters,
+            userPosition,
+          )
+        : eligibleServices,
+    [dashFilters.forYouOnly, eligibleServices, mapFilters, recommendedServices, userPosition],
+  );
+  const isForYouLoading = dashFilters.forYouOnly && isRecommendationsLoading;
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <Text>Loading services...</Text>
       </div>
     );
   }
 
   return (
-    <div>
-      <div className="grid grid-cols-1 md:grid-cols-2">
-        <div className="pr-4 space-y-2">
-          <CreateServiceDialog
-            onServiceCreated={fetchServices}
-            requiresNeedCreation={timebankData?.requires_need_creation}
-          />
+    <div className="space-y-4">
+      <CreateServiceDialog
+        onServiceCreated={fetchServices}
+        requiresNeedCreation={timebankData?.requires_need_creation}
+      />
 
-          {timebankData?.requires_need_creation && (
-            <Callout.Root color="amber" className="mb-4">
-              <Callout.Icon>
-                <HandIcon />
-              </Callout.Icon>
-              <Callout.Text>
-                You've reached the 10-hour surplus limit. Create a Need to help
-                balance the community and use your hours.
-              </Callout.Text>
-            </Callout.Root>
+      {timebankData?.requires_need_creation && (
+        <Callout.Root color="amber">
+          <Callout.Icon>
+            <HandIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            You've reached the 10-hour surplus limit. Create a Need to help
+            balance the community and use your hours.
+          </Callout.Text>
+        </Callout.Root>
+      )}
+
+      <Flex
+        gap="2"
+        className="sticky top-16 z-20 bg-background py-2"
+        direction="column"
+        id="dashboard-header"
+      >
+        <Flex align="center" gap="2" wrap="wrap">
+          <Crosshair1Icon className="h-4 w-4" />
+          <Text size="2" weight="medium" color="gray">
+            {isSearching
+              ? "Searching..."
+              : isForYouLoading
+                ? "Finding picks for you..."
+              : dashFilters.forYouOnly
+                ? `${displayedServices.length} picks for you`
+                : `${displayedServices.length} services found`}
+            {searchQuery && ` for "${searchQuery}"`}
+            {selectedCity && selectedCity !== "all" && ` in ${selectedCity}`}
+            {tagParam && ` with tag "${decodeURIComponent(tagParam)}"`}
+          </Text>
+          {tagParam && (
+            <Button
+              size="1"
+              variant="soft"
+              color="gray"
+              onClick={() => {
+                setSearchParams((prev) => {
+                  prev.delete("tag");
+                  return prev;
+                });
+              }}
+            >
+              Clear tag
+            </Button>
           )}
+        </Flex>
+        <DashboardFilterBar
+          filters={dashFilters}
+          onFiltersChange={handleDashFiltersChange}
+          availableTags={availableTags}
+          hasLocation={userPosition !== null}
+        />
+      </Flex>
 
-          {/* Services Count and Results */}
-          <Flex
-            gap="1"
-            className="sticky top-16 z-20 bg-background py-2 mb-2"
-            direction="column"
-            id="dashboard-header"
-          >
-            <Flex align="center" gap="2" wrap="wrap">
-              <Crosshair1Icon className="w-4 h-4" />
-              <Text size="2" weight="medium" color="gray">
-                {isSearching
-                  ? "Searching..."
-                  : `${displayedServices.length} services found`}
-                {searchQuery && ` for "${searchQuery}"`}
-                {selectedCity &&
-                  selectedCity !== "all" &&
-                  ` in ${selectedCity}`}
-                {tagParam && ` with tag "${decodeURIComponent(tagParam)}"`}
-              </Text>
-              {tagParam && (
-                <Button
-                  size="1"
-                  variant="soft"
-                  color="gray"
-                  onClick={() => {
-                    setSearchParams((prev) => {
-                      prev.delete("tag");
-                      return prev;
-                    });
-                  }}
-                >
-                  Clear tag
-                </Button>
-              )}
-            </Flex>
-            <DashboardFilterBar
-              filters={dashFilters}
-              onFiltersChange={handleDashFiltersChange}
-              availableTags={availableTags}
-              hasLocation={userPosition !== null}
-            />
-          </Flex>
-
+      <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1.08fr)_minmax(360px,0.92fr)]">
+        <div className="space-y-3 xl:pr-2">
           <div
-            className={`grid grid-cols-1 md:grid-cols-2 gap-3 transition-opacity duration-200 ${isSearching ? "opacity-50 pointer-events-none" : "opacity-100"}`}
+            className={`grid grid-cols-1 gap-3 transition-opacity duration-200 md:grid-cols-2 ${
+              isSearching || isForYouLoading
+                ? "pointer-events-none opacity-50"
+                : "opacity-100"
+            }`}
           >
             {displayedServices.map((service, index) => (
               <div
@@ -344,29 +437,42 @@ export function Dashboard() {
                 className="service-card-animate"
                 style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}
               >
-                <OfferListingCard service={service} />
+                <OfferListingCard
+                  service={service}
+                  isRecommended={dashFilters.forYouOnly}
+                  recommendationReason={
+                    dashFilters.forYouOnly
+                      ? recommendationReasonMap.get(service._id)
+                      : undefined
+                  }
+                />
               </div>
             ))}
           </div>
 
-          {/* No Results Message */}
-          {displayedServices.length === 0 && !loading && (
+          {displayedServices.length === 0 && !loading && !isForYouLoading && (
             <Card className="flex flex-col items-center justify-center">
               <Text size="3" color="gray">
-                No services found matching your criteria
+                {dashFilters.forYouOnly
+                  ? "No personalized recommendations found"
+                  : "No services found matching your criteria"}
               </Text>
               <Text size="2" color="gray" className="mt-2">
-                Try adjusting your search or city filter
+                {dashFilters.forYouOnly
+                  ? "Try broadening your filters to see more matches"
+                  : "Try adjusting your search or city filter"}
               </Text>
             </Card>
           )}
         </div>
+
         <ServiceMap
           services={displayedServices}
           events={forumEvents}
           filters={mapFilters}
           onFiltersChange={setMapFilters}
           userPosition={userPosition}
+          height="72vh"
         />
       </div>
     </div>
@@ -377,7 +483,7 @@ function CreateServiceDialog({
   onServiceCreated,
   requiresNeedCreation,
 }: {
-  onServiceCreated?: () => void;
+  onServiceCreated?: (searchValue?: string) => Promise<void>;
   requiresNeedCreation?: boolean;
 }) {
   const [showDialog, setShowDialog] = useState(false);
@@ -390,25 +496,27 @@ function CreateServiceDialog({
     <Dialog.Root open={showDialog} onOpenChange={setShowDialog}>
       <Dialog.Trigger>
         <Button className="add-service-button shadow-lg">
-          <PlusIcon className="w-10 h-10 stroke-4 stroke-black" />
+          <PlusIcon className="h-10 w-10 stroke-4 stroke-black" />
         </Button>
       </Dialog.Trigger>
       <Dialog.Content
         align="center"
         size="4"
-        className="p-4 md:p-12 overflow-y-auto"
+        className="overflow-y-auto p-4 md:p-12"
         aria-describedby={undefined}
-        maxWidth={"80vw"}
-        maxHeight={"80vh"}
+        maxWidth="80vw"
+        maxHeight="80vh"
       >
-        <div className="pb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 pb-4 md:grid-cols-2">
           {errorMessage && (
             <Text size="2" color="red" className="col-span-2 text-center">
               {errorMessage}
             </Text>
           )}
           <Box
-            className={`border-2 rounded-lg hover-card text-center py-4 px-8 ${selectedServiceType === "offer" ? "hover-card-selected offer" : ""} ${requiresNeedCreation ? "opacity-50 cursor-not-allowed" : ""}`}
+            className={`border-2 rounded-lg hover-card px-8 py-4 text-center ${
+              selectedServiceType === "offer" ? "hover-card-selected offer" : ""
+            } ${requiresNeedCreation ? "cursor-not-allowed opacity-50" : ""}`}
             onClick={() => {
               if (requiresNeedCreation) {
                 setErrorMessage(
@@ -419,8 +527,8 @@ function CreateServiceDialog({
               setSelectedServiceType("offer");
             }}
           >
-            <Heading size="5" className="flex items-center justify-center mb-1">
-              <SunIcon className="w-6 h-6 text-orange-500 mr-2" />
+            <Heading size="5" className="mb-1 flex items-center justify-center">
+              <SunIcon className="mr-2 h-6 w-6 text-orange-500" />
               Offer a Service
             </Heading>
             <Text size="2">
@@ -429,11 +537,13 @@ function CreateServiceDialog({
             </Text>
           </Box>
           <Box
-            className={`border-2 rounded-lg hover-card text-center py-4 px-10 ${selectedServiceType === "need" ? "hover-card-selected need" : ""}`}
+            className={`border-2 rounded-lg hover-card px-10 py-4 text-center ${
+              selectedServiceType === "need" ? "hover-card-selected need" : ""
+            }`}
             onClick={() => setSelectedServiceType("need")}
           >
-            <Heading size="5" className="flex items-center justify-center mb-1">
-              <HandIcon className="w-6 h-6 text-blue-500 mr-2" />
+            <Heading size="5" className="mb-1 flex items-center justify-center">
+              <HandIcon className="mr-2 h-6 w-6 text-blue-500" />
               Need a Service
             </Heading>
             <Text size="2">
@@ -446,7 +556,6 @@ function CreateServiceDialog({
           serviceType={selectedServiceType}
           onSuccess={() => {
             setShowDialog(false);
-            // Refresh services list after successful creation
             if (onServiceCreated) {
               onServiceCreated();
             }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
-import { AuthResponse, User, Service, ServiceListResponse, PotentialMatchListResponse, TimeBankResponse, TimeBankTransaction, LoginForm, RegisterForm, ServiceForm, Comment, CommentListResponse, CommentForm, JoinRequest, JoinRequestListResponse, JoinRequestForm, Transaction, TransactionListResponse, TransactionForm, ChatRoom, ChatRoomListResponse, ChatRoomForm, Message, MessageListResponse, MessageForm, UserSettings, PasswordChangeForm, AccountDeletionForm, BadgeSummary, Rating, RatingListResponse, RatingDetailedListResponse, RatingForm, ForumDiscussion, ForumDiscussionListResponse, ForumDiscussionForm, ForumEvent, ForumEventListResponse, ForumEventForm, ForumComment, ForumCommentListResponse } from '@/types';
+import { AuthResponse, User, Service, ServiceListResponse, PotentialMatchListResponse, RecommendedServiceListResponse, TimeBankResponse, TimeBankTransaction, LoginForm, RegisterForm, ServiceForm, Comment, CommentListResponse, CommentForm, JoinRequest, JoinRequestListResponse, JoinRequestForm, Transaction, TransactionListResponse, TransactionForm, ChatRoom, ChatRoomListResponse, ChatRoomForm, Message, MessageListResponse, MessageForm, UserSettings, PasswordChangeForm, AccountDeletionForm, BadgeSummary, Rating, RatingListResponse, RatingDetailedListResponse, RatingForm, ForumDiscussion, ForumDiscussionListResponse, ForumDiscussionForm, ForumEvent, ForumEventListResponse, ForumEventForm, ForumComment, ForumCommentListResponse } from '@/types';
 
 // Use relative URL /api to leverage nginx proxy, or absolute URL if provided via env var
 // This ensures requests go through the same HTTPS domain as the frontend
@@ -206,6 +206,23 @@ export const servicesApi = {
 
   getSavedServiceIds: (): Promise<AxiosResponse<{ service_ids: string[] }>> =>
     api.get('/services/saved/ids'),
+
+  getRecommendedServices: (params?: {
+    page?: number;
+    limit?: number;
+    q?: string;
+    service_type?: string;
+    category?: string;
+    tags?: string;
+    status?: string;
+    city?: string;
+    latitude?: number;
+    longitude?: number;
+    radius?: number;
+    is_remote?: boolean;
+    date_filter?: string;
+  }): Promise<AxiosResponse<RecommendedServiceListResponse>> =>
+    api.get('/services/recommendations', { params }),
 
   getPotentialMatches: (id: string, limit = 4): Promise<AxiosResponse<PotentialMatchListResponse>> =>
     api.get(`/services/${id}/potential-matches`, { params: { limit } }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -238,6 +238,20 @@ export interface PotentialMatchListResponse {
   total: number;
 }
 
+export interface RecommendedServiceItem {
+  service: Service;
+  reason: string;
+  score: number;
+  matched_interests: string[];
+}
+
+export interface RecommendedServiceListResponse {
+  items: RecommendedServiceItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 export interface AuthResponse {
   access_token: string;
   token_type: string;


### PR DESCRIPTION
## Summary

This PR improves dashboard discovery by moving personalized recommendations into a dedicated `For you` filter instead of showing them in a separate section above the feed.

Recommended posts now appear directly in the main feed and map when `For you` is active, with clearer visual styling and a short explanation for why each post is recommended.

## What Changed

- Added a `For you` filter to the dashboard
- Added a heart icon next to `For you`
- Updated filter pills so they wrap and stay visible
- Removed the separate recommendation section above the feed
- Showed recommended posts directly in the main feed and map
- Added recommendation reasons to recommended cards
- Updated recommended card styling and header layout
- Fixed owner username display so it is no longer truncated

## Recommendation Logic

The current rule-based recommendation system uses:

- saved services
- previous transactions / exchanges
- user interests
- distance
- active search query
- selected city
- freshness / recency

It excludes:

- the current user’s own posts
- already saved posts
- posts already involved in the user’s transactions
