### PR TITLE
Tighten interest matching for "for you" filter results

### DIFF
--- a/backend/app/services/service_service.py
+++ b/backend/app/services/service_service.py
@@ -347,6 +347,63 @@ class ServiceService:
             )
         )
 
+    def _get_interest_match_fields(self, service_like: dict) -> List[str]:
+        fields: List[str] = []
+        for value in (
+            service_like.get("title"),
+            service_like.get("description"),
+            service_like.get("category"),
+        ):
+            normalized_value = self._normalize_text_value(value)
+            if normalized_value:
+                fields.append(normalized_value)
+
+        for tag in service_like.get("tags") or []:
+            if isinstance(tag, str):
+                normalized_value = self._normalize_text_value(tag)
+                if normalized_value:
+                    fields.append(normalized_value)
+                continue
+
+            if not isinstance(tag, dict):
+                normalized_value = self._normalize_text_value(tag)
+                if normalized_value:
+                    fields.append(normalized_value)
+                continue
+
+            for value in (tag.get("label"), tag.get("entityId")):
+                normalized_value = self._normalize_text_value(value)
+                if normalized_value:
+                    fields.append(normalized_value)
+
+            aliases = tag.get("aliases")
+            if isinstance(aliases, list):
+                for alias in aliases:
+                    normalized_value = self._normalize_text_value(alias)
+                    if normalized_value:
+                        fields.append(normalized_value)
+
+        return fields
+
+    def _contains_whole_phrase(self, text: Optional[str], phrase: Optional[str]) -> bool:
+        normalized_text = self._normalize_text_value(text)
+        normalized_phrase = self._normalize_text_value(phrase)
+        if not normalized_text or not normalized_phrase:
+            return False
+
+        pattern = rf"(?<!\w){re.escape(normalized_phrase)}(?!\w)"
+        return re.search(pattern, normalized_text) is not None
+
+    def _service_matches_interest(
+        self,
+        service_doc: dict,
+        normalized_interest: str,
+    ) -> bool:
+        return any(
+            self._contains_whole_phrase(field, normalized_interest)
+            for field in self._get_interest_match_fields(service_doc)
+        )
+
     def _build_similarity_profile(self, service_like: dict) -> Tuple[Set[str], Set[str]]:
         tag_labels = self._get_tag_labels(service_like.get("tags"))
         location = service_like.get("location") or {}
@@ -905,8 +962,10 @@ class ServiceService:
             matched_interests = [
                 interest["label"]
                 for interest in normalized_interests
-                if interest["normalized"] in candidate_profile[0]
-                or interest["normalized"] in content_blob
+                if self._service_matches_interest(
+                    service_doc,
+                    interest["normalized"],
+                )
             ]
             saved_similarity = self._max_profile_similarity(
                 candidate_profile,

--- a/backend/tests/test_service_service.py
+++ b/backend/tests/test_service_service.py
@@ -180,6 +180,126 @@ class TestServiceService:
         assert len(items) == 1
         assert items[0].service.id == str(similar_offer.id)
         assert items[0].service.service_type == ServiceType.OFFER
+
+    @pytest.mark.asyncio
+    async def test_get_recommended_services_ignores_interest_substrings_in_words(
+        self, mock_db, test_user, second_user, sample_service_data
+    ):
+        """Interest matches should not be triggered by substrings such as health->healthy."""
+        from bson import ObjectId
+        from app.models.service import ServiceCreate
+
+        service_service = ServiceService(mock_db)
+
+        await mock_db.users.update_one(
+            {"_id": ObjectId(str(test_user.id))},
+            {"$set": {"interests": ["Health"]}},
+        )
+
+        unrelated_service_data = sample_service_data.copy()
+        unrelated_service_data.update(
+            {
+                "title": "Home Cooking / Meal Prep",
+                "description": "Share healthy cooking ideas and easy dinner prep.",
+                "category": "cooking",
+                "tags": ["cooking", "food"],
+            }
+        )
+        await service_service.create_service(
+            ServiceCreate(**unrelated_service_data),
+            str(second_user.id),
+        )
+
+        items, total = await service_service.get_recommended_services(
+            user_id=str(test_user.id),
+            filters=ServiceFilters(),
+            page=1,
+            limit=10,
+        )
+
+        assert total == 0
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_get_recommended_services_ignores_short_interest_inside_other_words(
+        self, mock_db, test_user, second_user, sample_service_data
+    ):
+        """Short interests such as AI should only match whole terms, not word fragments."""
+        from bson import ObjectId
+        from app.models.service import ServiceCreate
+
+        service_service = ServiceService(mock_db)
+
+        await mock_db.users.update_one(
+            {"_id": ObjectId(str(test_user.id))},
+            {"$set": {"interests": ["AI"]}},
+        )
+
+        unrelated_service_data = sample_service_data.copy()
+        unrelated_service_data.update(
+            {
+                "title": "Watercolor Portrait Of My Pet",
+                "description": "Bring a painting reference for a birthday portrait workshop.",
+                "category": "art",
+                "tags": ["Watercolor Painting", "Portrait"],
+            }
+        )
+        await service_service.create_service(
+            ServiceCreate(**unrelated_service_data),
+            str(second_user.id),
+        )
+
+        items, total = await service_service.get_recommended_services(
+            user_id=str(test_user.id),
+            filters=ServiceFilters(),
+            page=1,
+            limit=10,
+        )
+
+        assert total == 0
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_get_recommended_services_matches_interest_as_whole_term(
+        self, mock_db, test_user, second_user, sample_service_data
+    ):
+        """Whole-word interest matches should still produce recommendations."""
+        from bson import ObjectId
+        from app.models.service import ServiceCreate
+
+        service_service = ServiceService(mock_db)
+
+        await mock_db.users.update_one(
+            {"_id": ObjectId(str(test_user.id))},
+            {"$set": {"interests": ["AI"]}},
+        )
+
+        matching_service_data = sample_service_data.copy()
+        matching_service_data.update(
+            {
+                "title": "AI Interview Practice",
+                "description": "Practice AI interview questions together.",
+                "category": "technology",
+                "tags": ["career", "AI"],
+            }
+        )
+        matching_service = await service_service.create_service(
+            ServiceCreate(**matching_service_data),
+            str(second_user.id),
+        )
+
+        items, total = await service_service.get_recommended_services(
+            user_id=str(test_user.id),
+            filters=ServiceFilters(),
+            page=1,
+            limit=10,
+        )
+
+        assert total == 1
+        assert len(items) == 1
+        assert items[0].service.id == str(matching_service.id)
+        assert items[0].matched_interests == ["AI"]
+        assert items[0].reason == "Because it matches your interest in AI"
     
     @pytest.mark.asyncio
     async def test_update_service(self, mock_db, sample_service):


### PR DESCRIPTION
## Summary

This PR fixes false-positive matches in the "For you" recommendation feed.

Previously, recommendation interest matching used loose substring checks across service content. That caused unrelated posts to appear as recommended, such as:

- `Health` matching `healthy`
- `AI` matching word fragments inside unrelated text

## What changed

- limited interest matching to structured service fields
  - title
  - description
  - category
  - tags
- replaced loose substring matching with whole-word / whole-phrase matching
- added regression coverage for known false-positive cases
- preserved valid whole-term matches so relevant recommendations still appear

## Why

Users were seeing misleading recommendation reasons like "Because it matches your interest in AI" or "Health" for clearly unrelated posts. This change makes recommendation explanations more trustworthy and improves feed relevance.

## Testing

- added service-layer tests for:
  - `Health` should not match `healthy`
  - `AI` should not match word fragments in unrelated content
  - valid `AI` whole-term matches should still be recommended

## Notes

- this is a backend-only recommendation fix
- frontend behavior remains the same and now reflects cleaner API results

It closes #221 
It closes #223 