### PR TITLE
feat: add functionality to create group chat rooms for active services

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -98,6 +98,23 @@ async def update_chat_room(
             detail=str(e)
         )
 
+@router.post("/rooms/service/{service_id}", response_model=ChatRoomResponse)
+async def create_service_group_chat_room(
+    service_id: str,
+    current_user: UserResponse = Depends(get_current_user),
+    db=Depends(get_database)
+):
+    """Create a group chat room for an active service (provider only)"""
+    chat_service = ChatService(db)
+    try:
+        room = await chat_service.create_room_for_service(service_id, str(current_user.id))
+        return room
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
 @router.post("/rooms/transaction/{transaction_id}", response_model=ChatRoomResponse)
 async def create_transaction_chat_room(
     transaction_id: str,

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -377,6 +377,49 @@ class ChatService:
         except Exception:
             return None
 
+    async def create_room_for_service(self, service_id: str, creator_id: str) -> ChatRoomResponse:
+        """Create a group chat room for an active service (provider only, includes all matched users)"""
+        try:
+            service = await self.services_collection.find_one({"_id": ObjectId(service_id)})
+            if not service:
+                raise ValueError("Service not found")
+
+            if str(service["user_id"]) != creator_id:
+                raise ValueError("Only the service provider can create a group chat")
+
+            matched_user_ids = service.get("matched_user_ids", [])
+            if not matched_user_ids:
+                raise ValueError("No matched users yet — cannot create a group chat")
+
+            participant_ids = [ObjectId(creator_id)] + [ObjectId(uid) for uid in matched_user_ids]
+
+            # Return existing active group chat for this service if one exists
+            existing_room = await self.chat_rooms_collection.find_one({
+                "service_ids": ObjectId(service_id),
+                "is_active": True
+            })
+            if existing_room:
+                return await self._populate_room_response(existing_room)
+
+            room_doc = {
+                "name": service["title"],
+                "description": f"Group chat for service: {service['title']}",
+                "is_active": True,
+                "participant_ids": participant_ids,
+                "service_ids": [ObjectId(service_id)],
+                "transaction_id": None,
+                "created_at": datetime.utcnow(),
+                "updated_at": datetime.utcnow(),
+                "last_message_at": None,
+            }
+
+            result = await self.chat_rooms_collection.insert_one(room_doc)
+            room_doc["_id"] = result.inserted_id
+
+            return await self._populate_room_response(room_doc)
+        except Exception as e:
+            raise ValueError(f"Error creating service group chat room: {str(e)}")
+
     async def create_room_for_transaction(self, transaction_id: str, creator_id: str) -> ChatRoomResponse:
         """Create a chat room for a specific transaction"""
         try:

--- a/frontend/src/pages/MyServices.tsx
+++ b/frontend/src/pages/MyServices.tsx
@@ -259,6 +259,18 @@ export function MyServices({
     }
   };
 
+  const handleCreateGroupChat = async (serviceId: string) => {
+    try {
+      const { data } = await chatApi.createServiceGroupChatRoom(serviceId);
+      const roomId = data?._id;
+      navigate(
+        roomId ? `/profile?tab=chat&room_id=${roomId}` : "/profile?tab=chat",
+      );
+    } catch (error) {
+      console.error("Error creating group chat:", error);
+    }
+  };
+
   const handleStartChat = async (transactionId: string) => {
     const allTransactions = Object.values(serviceTransactions).flat();
     const transaction = allTransactions.find((t) => t._id === transactionId);
@@ -451,6 +463,7 @@ export function MyServices({
 onDeleteService={handleDeleteService}
             onCancelService={handleCancelService}
             onStartChat={handleStartChat}
+            onCreateGroupChat={handleCreateGroupChat}
             onCancelTransaction={handleCancelTransaction}
             onConfirmTransactionCompletion={handleConfirmTransactionCompletion}
             onRequestUpdate={fetchData}

--- a/frontend/src/pages/MyServicesTab.tsx
+++ b/frontend/src/pages/MyServicesTab.tsx
@@ -27,6 +27,7 @@ import {
   TrashIcon,
   CrossCircledIcon,
   Pencil1Icon,
+  ChatBubbleIcon,
 } from "@radix-ui/react-icons";
 import { useNavigate } from "react-router-dom";
 
@@ -39,6 +40,7 @@ interface MyServicesTabProps {
   onDeleteService: (serviceId: string) => Promise<void>;
   onCancelService: (serviceId: string) => Promise<void>;
   onStartChat: (transactionId: string) => Promise<void>;
+  onCreateGroupChat: (serviceId: string) => Promise<void>;
   onCancelTransaction: (transactionId: string) => Promise<void>;
   onConfirmTransactionCompletion: (
     transactionId: string,
@@ -66,6 +68,7 @@ export function MyServicesTab({
   onDeleteService,
   onCancelService,
   onStartChat,
+  onCreateGroupChat,
   onCancelTransaction,
   onConfirmTransactionCompletion,
   onRequestUpdate,
@@ -329,6 +332,25 @@ export function MyServicesTab({
                                   </Button>
                                 </Tooltip>
                               )}
+
+                              {/* Group Chat button for active services with matched users */}
+                              {service.status === "active" &&
+                                service.matched_user_ids &&
+                                service.matched_user_ids.length > 0 && (
+                                  <Tooltip content="Create group chat with matched users">
+                                    <Button
+                                      size="2"
+                                      color="teal"
+                                      variant="soft"
+                                      onClick={() =>
+                                        onCreateGroupChat(service._id)
+                                      }
+                                    >
+                                      <ChatBubbleIcon className="w-4 h-4 mr-2" />
+                                      Group Chat
+                                    </Button>
+                                  </Tooltip>
+                                )}
 
                               <Tooltip content="Cancel service">
                                 <Button

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -324,6 +324,9 @@ export const chatApi = {
   
   createTransactionChatRoom: (transactionId: string): Promise<AxiosResponse<ChatRoom>> =>
     api.post(`/chat/rooms/transaction/${transactionId}`),
+
+  createServiceGroupChatRoom: (serviceId: string): Promise<AxiosResponse<ChatRoom>> =>
+    api.post(`/chat/rooms/service/${serviceId}`),
   
   // Messages
   sendMessage: (data: MessageForm): Promise<AxiosResponse<Message>> =>


### PR DESCRIPTION
                                                                                                                                                                                                                        
  **Backend**                                                                                                                                                                                                                
  - chat_service.py: create_room_for_service() — verifies caller is the service provider, collects all matched_user_ids, creates a group chat room with service info, and returns any existing one if it already exists  
  for that service                                                                                                                                                                                                       
  - chat.py: POST /chat/rooms/service/{service_id} endpoint                                                                                                                                                              
                                                                                                                                                                                                                         
  **Frontend**                                                                                                                                                                                                               
  - api.ts: chatApi.createServiceGroupChatRoom(serviceId)
  - MyServicesTab.tsx: "Group Chat" button (teal, soft) shown when service is active and has matched users, with ChatBubbleIcon                                                                                          
  - MyServices.tsx: handleCreateGroupChat handler that calls the endpoint and navigates to the chat page with the new room selected                                                                                    
                                                                                                                                                                                                                         
  _The button only appears for the provider's own active services that have at least one matched user._           
  
<img width="630" height="174" alt="Screenshot 2026-04-06 at 22 55 56" src="https://github.com/user-attachments/assets/d9b70172-1bbb-4b65-b07a-b79a6cb8e2d2" />


