### PR TITLE
Fix: Rating images not uploaded or displayed in MyServicesTab         

### DIFF
--- a/frontend/src/components/ui/ApplicantsList.tsx
+++ b/frontend/src/components/ui/ApplicantsList.tsx
@@ -87,7 +87,7 @@ export function ApplicantsList({
           ...prev,
           [userId]: u,
         }));
-        console.log(users);
+        // console.log(users);
       } catch {
         // keep fallback
       }

--- a/frontend/src/components/ui/ImageGallery.tsx
+++ b/frontend/src/components/ui/ImageGallery.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Dialog, Flex } from "@radix-ui/themes";
+import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import { getImageUrl } from "@/services/api";
+
+interface ImageGalleryProps {
+  urls: string[];
+  alt?: string;
+  /** "thumbnails" — small fixed-size squares (for ratings, comments, etc.)
+   *  "grid"       — responsive full-width grid (for service detail pages) */
+  layout?: "thumbnails" | "grid";
+  className?: string;
+}
+
+export function ImageGallery({
+  urls,
+  alt = "Photo",
+  layout = "thumbnails",
+  className,
+}: ImageGalleryProps) {
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  if (!urls.length) return null;
+
+  const resolvedUrls = urls.map((u) => getImageUrl(u) ?? u);
+
+  const openAt = (i: number) => setLightboxIndex(i);
+  const close = () => setLightboxIndex(null);
+  const prev = () =>
+    setLightboxIndex((i) => (i === null ? null : (i - 1 + urls.length) % urls.length));
+  const next = () =>
+    setLightboxIndex((i) => (i === null ? null : (i + 1) % urls.length));
+
+  const thumbnails =
+    layout === "thumbnails" ? (
+      <Flex gap="2" wrap="wrap" className={className}>
+        {resolvedUrls.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt={`${alt} ${i + 1}`}
+            className="w-20 h-20 object-cover rounded cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => openAt(i)}
+          />
+        ))}
+      </Flex>
+    ) : (
+      <div
+        className={`grid gap-1 w-full ${
+          urls.length === 1
+            ? "grid-cols-1"
+            : urls.length === 2
+              ? "grid-cols-2"
+              : "grid-cols-3"
+        } ${className ?? ""}`}
+      >
+        {resolvedUrls.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt={`${alt} ${i + 1}`}
+            className="w-full max-h-80 object-contain rounded-lg cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => openAt(i)}
+          />
+        ))}
+      </div>
+    );
+
+  return (
+    <>
+      {thumbnails}
+
+      <Dialog.Root open={lightboxIndex !== null} onOpenChange={(open) => !open && close()}>
+        <Dialog.Content
+          maxWidth="90vw"
+          className="p-2 flex flex-col items-center gap-3"
+          aria-describedby={undefined}
+        >
+          {lightboxIndex !== null && (
+            <>
+              <img
+                src={resolvedUrls[lightboxIndex]}
+                alt={`${alt} ${lightboxIndex + 1}`}
+                className="max-h-[80vh] max-w-full mx-auto rounded object-contain"
+              />
+              {urls.length > 1 && (
+                <Flex gap="3" align="center" justify="center">
+                  <button
+                    onClick={prev}
+                    aria-label="Previous photo"
+                    className="p-1 rounded hover:bg-[var(--gray-4)] transition-colors"
+                  >
+                    <ChevronLeftIcon width={20} height={20} />
+                  </button>
+                  <span className="text-sm text-[var(--gray-11)]">
+                    {lightboxIndex + 1} / {urls.length}
+                  </span>
+                  <button
+                    onClick={next}
+                    aria-label="Next photo"
+                    className="p-1 rounded hover:bg-[var(--gray-4)] transition-colors"
+                  >
+                    <ChevronRightIcon width={20} height={20} />
+                  </button>
+                </Flex>
+              )}
+            </>
+          )}
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/frontend/src/components/ui/ReviewCard.tsx
+++ b/frontend/src/components/ui/ReviewCard.tsx
@@ -1,10 +1,9 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Card, Flex, Text, Badge, Button, Dialog } from "@radix-ui/themes";
+import { Card, Flex, Text, Badge, Button } from "@radix-ui/themes";
 import { RatingStars } from "@/components/ui/RatingStars";
 import { InterestChip } from "@/components/ui/InterestChip";
 import { tagToLabel } from "@/components/ui/ConfirmCompletionModal";
-import { getImageUrl } from "@/services/api";
+import { ImageGallery } from "@/components/ui/ImageGallery";
 import type { RatingDetailed } from "@/types";
 
 interface ReviewCardProps {
@@ -13,7 +12,6 @@ interface ReviewCardProps {
 
 export function ReviewCard({ rating }: ReviewCardProps) {
   const navigate = useNavigate();
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
   const raterLabel = rating.rater
     ? rating.rater.full_name || `@${rating.rater.username}`
@@ -89,34 +87,9 @@ export function ReviewCard({ rating }: ReviewCardProps) {
         )}
 
         {rating.image_urls && rating.image_urls.length > 0 && (
-          <Flex gap="2" wrap="wrap">
-            {rating.image_urls.map((url, i) => (
-              <img
-                key={i}
-                src={getImageUrl(url)}
-                alt={`Review photo ${i + 1}`}
-                className="w-20 h-20 object-cover rounded cursor-pointer hover:opacity-90 transition-opacity"
-                onClick={() => setLightboxSrc(getImageUrl(url) ?? null)}
-              />
-            ))}
-          </Flex>
+          <ImageGallery urls={rating.image_urls} alt="Review photo" />
         )}
       </Flex>
-
-      <Dialog.Root
-        open={lightboxSrc !== null}
-        onOpenChange={(open) => !open && setLightboxSrc(null)}
-      >
-        <Dialog.Content maxWidth="90vw" className="p-2">
-          {lightboxSrc && (
-            <img
-              src={lightboxSrc}
-              alt="Review photo"
-              className="max-h-[80vh] max-w-full mx-auto rounded"
-            />
-          )}
-        </Dialog.Content>
-      </Dialog.Root>
     </Card>
   );
 }

--- a/frontend/src/pages/MyApplicationsTab.tsx
+++ b/frontend/src/pages/MyApplicationsTab.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/ConfirmCompletionModal";
 import { InterestChip } from "@/components/ui/InterestChip";
 import { ratingsApi, usersApi } from "@/services/api";
+import { ImageGallery } from "@/components/ui/ImageGallery";
 import { CheckCircledIcon } from "@radix-ui/react-icons";
 
 interface MyApplicationsTabProps {
@@ -448,6 +449,14 @@ export function MyApplicationsTab({
                                                       "{myRating.comment}"
                                                     </Text>
                                                   )}
+                                                  {myRating.image_urls &&
+                                                    myRating.image_urls.length > 0 && (
+                                                      <ImageGallery
+                                                        urls={myRating.image_urls}
+                                                        alt="Review photo"
+                                                        className="mt-1"
+                                                      />
+                                                    )}
                                                 </Flex>
                                               ) : myTransactionAny.provider_confirmed ? (
                                                 <RatingForm

--- a/frontend/src/pages/MyServicesTab.tsx
+++ b/frontend/src/pages/MyServicesTab.tsx
@@ -20,7 +20,8 @@ import {
 import { InterestChip } from "@/components/ui/InterestChip";
 import { EditServiceDialog } from "@/components/forms/EditServiceDialog";
 import { ServicesSummaryCard } from "@/components/ui/ServicesSummaryCard";
-import { ratingsApi, getImageUrl } from "@/services/api";
+import { ratingsApi } from "@/services/api";
+import { ImageGallery } from "@/components/ui/ImageGallery";
 import {
   ClockIcon,
   CheckCircledIcon,
@@ -577,16 +578,11 @@ export function MyServicesTab({
                                           )}
                                           {myRating.image_urls &&
                                             myRating.image_urls.length > 0 && (
-                                              <Flex gap="2" wrap="wrap" className="mt-1">
-                                                {myRating.image_urls.map((url, i) => (
-                                                  <img
-                                                    key={i}
-                                                    src={getImageUrl(url)}
-                                                    alt={`Review photo ${i + 1}`}
-                                                    className="w-20 h-20 object-cover rounded"
-                                                  />
-                                                ))}
-                                              </Flex>
+                                              <ImageGallery
+                                                urls={myRating.image_urls}
+                                                alt="Review photo"
+                                                className="mt-1"
+                                              />
                                             )}
                                         </Flex>
                                       )}

--- a/frontend/src/pages/MyServicesTab.tsx
+++ b/frontend/src/pages/MyServicesTab.tsx
@@ -20,7 +20,7 @@ import {
 import { InterestChip } from "@/components/ui/InterestChip";
 import { EditServiceDialog } from "@/components/forms/EditServiceDialog";
 import { ServicesSummaryCard } from "@/components/ui/ServicesSummaryCard";
-import { ratingsApi } from "@/services/api";
+import { ratingsApi, getImageUrl } from "@/services/api";
 import {
   ClockIcon,
   CheckCircledIcon,
@@ -50,6 +50,7 @@ interface MyServicesTabProps {
       score: number;
       comment?: string;
       tags: string[];
+      image_urls?: string[];
     },
   ) => Promise<void>;
   onRequestUpdate: () => void;
@@ -125,6 +126,7 @@ export function MyServicesTab({
       score: data.score,
       comment: data.comment || undefined,
       tags: data.tags,
+      image_urls: data.image_urls,
     });
 
     try {
@@ -481,7 +483,6 @@ export function MyServicesTab({
                                         String(currentUserId) ||
                                       (r.rater as any)?.id === currentUserId,
                                   );
-
                                   const transactionStatus =
                                     transaction.provider_confirmed &&
                                     transaction.requester_confirmed
@@ -574,6 +575,19 @@ export function MyServicesTab({
                                               "{myRating.comment}"
                                             </Text>
                                           )}
+                                          {myRating.image_urls &&
+                                            myRating.image_urls.length > 0 && (
+                                              <Flex gap="2" wrap="wrap" className="mt-1">
+                                                {myRating.image_urls.map((url, i) => (
+                                                  <img
+                                                    key={i}
+                                                    src={getImageUrl(url)}
+                                                    alt={`Review photo ${i + 1}`}
+                                                    className="w-20 h-20 object-cover rounded"
+                                                  />
+                                                ))}
+                                              </Flex>
+                                            )}
                                         </Flex>
                                       )}
 

--- a/frontend/src/pages/ServiceDetail.tsx
+++ b/frontend/src/pages/ServiceDetail.tsx
@@ -23,8 +23,8 @@ import {
   usersApi,
   joinRequestsApi,
   forumApi,
-  getImageUrl,
 } from "@/services/api";
+import { ImageGallery } from "@/components/ui/ImageGallery";
 import { useUser } from "@/App";
 import {
   ClockIcon,
@@ -584,32 +584,11 @@ export function ServiceDetail() {
           {/* Images */}
           {service.image_urls?.length ? (
             <div className="w-full mb-6 overflow-hidden rounded-lg">
-              {service.image_urls.length === 1 ? (
-                <img
-                  src={
-                    getImageUrl(service.image_urls[0]) ?? service.image_urls[0]
-                  }
-                  alt=""
-                  className="max-h-80 object-contain rounded-lg"
-                />
-              ) : (
-                <div
-                  className={`grid gap-1 w-full ${
-                    service.image_urls.length === 2
-                      ? "grid-cols-2"
-                      : "grid-cols-3"
-                  }`}
-                >
-                  {service.image_urls.map((url, i) => (
-                    <img
-                      key={i}
-                      src={getImageUrl(url) ?? url}
-                      alt=""
-                      className="w-full max-h-80 object-contain rounded-lg"
-                    />
-                  ))}
-                </div>
-              )}
+              <ImageGallery
+                urls={service.image_urls}
+                alt="Service photo"
+                layout="grid"
+              />
             </div>
           ) : null}
           {/* Details */}


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                         
  When a service owner confirmed a transaction and submitted a rating with                                                                                                                                                                                                                                                                               
  photos, the images were silently dropped in two places:                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                         
  1. **Not sent to the API** — `handleConfirmWithRating` in `MyServicesTab`                                                                                                                                                                                                                                                                              
     built the rating payload without `image_urls`, so uploaded photos never                                                                                                                                                                                                                                                                             
     reached the backend even though `ConfirmCompletionModal` had already                                                                                                                                                                                                                                                                                
     uploaded them and returned the URLs.                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                         
  2. **Not rendered** — Even for ratings that somehow had `image_urls` stored,                                                                                                                                                                                                                                                                           
     the field was never rendered in the transaction confirmation section.                                                                                                                                                                                                                                                                               
     Only stars, tags, and comment were shown. A stray `console.log` for                                                                                                                                                                                                                                                                                 
     debugging was also left behind.                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                         
 ### Fix                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                         
  - Pass `image_urls` from `ConfirmCompletionRatingData` through                                                                                                                                                                                                                                                                                         
    `handleConfirmWithRating` → `onConfirmTransactionCompletion` → `ratingsApi.createRating`.                                                                                                                                                                                                                                                          
  - Add `image_urls?` to the `onConfirmTransactionCompletion` prop type so                                                                                                                                                                                                                                                                               
    TypeScript enforces it going forward.
  - Render uploaded images below the comment in the rating display block,                                                                                                                                                                                                                                                                                
    consistent with the existing `ReviewCard` pattern.
  - Remove the debug `console.log`.            
  