### PR TITLE
feat: event attendance, attendee avatars, and rich map popups

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.hive.hive_app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.1.3"
+        versionCode = 6
+        versionName = "1.1.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BASE_URL", "\"https://backend-swe.gnahh5.easypanel.host\"")

--- a/app/app/src/main/java/com/hive/hive_app/data/api/ForumApi.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/api/ForumApi.kt
@@ -10,7 +10,7 @@ import com.hive.hive_app.data.api.dto.ForumDiscussionResponse
 import com.hive.hive_app.data.api.dto.ForumDiscussionUpdate
 import com.hive.hive_app.data.api.dto.ForumEventCreate
 import com.hive.hive_app.data.api.dto.ForumEventListResponse
-import com.hive.hive_app.data.api.dto.ForumEventAttendeesResponse
+import com.hive.hive_app.data.api.dto.ForumUserEmbed
 import com.hive.hive_app.data.api.dto.ForumEventResponse
 import com.hive.hive_app.data.api.dto.ForumEventUpdate
 import retrofit2.Response
@@ -72,7 +72,13 @@ interface ForumApi {
     suspend fun deleteEvent(@Path("event_id") eventId: String): Response<Unit>
 
     @GET("forum/events/{event_id}/attendees")
-    suspend fun getEventAttendees(@Path("event_id") eventId: String): Response<ForumEventAttendeesResponse>
+    suspend fun getEventAttendees(@Path("event_id") eventId: String): Response<List<ForumUserEmbed>>
+
+    @POST("forum/events/{event_id}/attend")
+    suspend fun attendEvent(@Path("event_id") eventId: String): Response<ForumEventResponse>
+
+    @DELETE("forum/events/{event_id}/attend")
+    suspend fun unattendEvent(@Path("event_id") eventId: String): Response<ForumEventResponse>
 
     @GET("forum/comments")
     suspend fun listComments(

--- a/app/app/src/main/java/com/hive/hive_app/data/api/dto/ForumDto.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/api/dto/ForumDto.kt
@@ -125,11 +125,6 @@ data class ForumEventResponse(
 )
 
 @JsonClass(generateAdapter = true)
-data class ForumEventAttendeesResponse(
-    val attendees: List<ForumUserEmbed>? = null
-)
-
-@JsonClass(generateAdapter = true)
 data class ForumEventListResponse(
     val events: List<ForumEventResponse>,
     val total: Int,
@@ -143,5 +138,6 @@ data class ForumEventListResponse(
 data class ForumUserEmbed(
     @Json(name = "_id") val id: String? = null,
     val username: String? = null,
-    @Json(name = "full_name") val fullName: String? = null
+    @Json(name = "full_name") val fullName: String? = null,
+    @Json(name = "profile_picture") val profilePicture: String? = null
 )

--- a/app/app/src/main/java/com/hive/hive_app/data/repository/ForumRepository.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/repository/ForumRepository.kt
@@ -133,8 +133,34 @@ class ForumRepository @Inject constructor(
         return try {
             val response = forumApi.getEventAttendees(eventId)
             if (response.isSuccessful && response.body() != null) {
-                val list = response.body()!!.attendees ?: emptyList()
+                val list = response.body()!!
                 Result.success(list)
+            } else {
+                Result.failure(HttpException(response))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun attendEvent(eventId: String): Result<ForumEventResponse> {
+        return try {
+            val response = forumApi.attendEvent(eventId)
+            if (response.isSuccessful && response.body() != null) {
+                Result.success(response.body()!!)
+            } else {
+                Result.failure(HttpException(response))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun unattendEvent(eventId: String): Result<ForumEventResponse> {
+        return try {
+            val response = forumApi.unattendEvent(eventId)
+            if (response.isSuccessful && response.body() != null) {
+                Result.success(response.body()!!)
             } else {
                 Result.failure(HttpException(response))
             }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ForumScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ForumScreen.kt
@@ -27,10 +27,13 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.ChatBubble
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -73,10 +76,13 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.core.content.ContextCompat
 import android.content.Context
 import androidx.compose.ui.viewinterop.AndroidView
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 
 @Composable
 fun ForumScreen(
     modifier: Modifier = Modifier,
+    onOpenUserProfile: (String) -> Unit = {},
     viewModel: ForumViewModel = hiltViewModel()
 ) {
     var selectedDiscussionId by remember { mutableStateOf<String?>(null) }
@@ -122,6 +128,7 @@ fun ForumScreen(
                 viewModel.clearEventDetail()
                 selectedEventId = null
             },
+            onOpenUserProfile = onOpenUserProfile,
             modifier = modifier
         )
         return
@@ -341,8 +348,10 @@ private fun ForumEventMap(
 }
 
 private fun forumUserInitials(user: ForumUserEmbed?): String {
-    val name = user?.fullName?.takeIf { it.isNotBlank() } ?: user?.username ?: "?"
-    return name.take(2).uppercase()
+    val name = user?.username?.takeIf { it.isNotBlank() }
+        ?: user?.fullName?.takeIf { it.isNotBlank() }
+        ?: "?"
+    return name.trim().firstOrNull()?.uppercase() ?: "?"
 }
 
 @Composable
@@ -599,6 +608,7 @@ private fun ForumEventCard(
 fun ForumEventDetailContent(
     viewModel: ForumViewModel,
     onBack: () -> Unit,
+    onOpenUserProfile: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val eventDetailState by viewModel.eventDetailState.collectAsState()
@@ -720,6 +730,47 @@ fun ForumEventDetailContent(
                         }
                     }
                     item {
+                        val currentUserId = eventDetailState.currentUserId
+                        val isOrganizer = currentUserId != null && event.userId == currentUserId
+                        val isAttending = currentUserId != null &&
+                                event.attendeeIds?.contains(currentUserId) == true
+
+                        if (currentUserId != null && !isOrganizer) {
+                            if (isAttending) {
+                                OutlinedButton(
+                                    onClick = { viewModel.toggleAttend(event.id) },
+                                    enabled = !eventDetailState.isAttendingLoading,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = ButtonDefaults.outlinedButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.error
+                                    )
+                                ) {
+                                    if (eventDetailState.isAttendingLoading) {
+                                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                    } else {
+                                        Text("Leave")
+                                    }
+                                }
+                            } else {
+                                Button(
+                                    onClick = { viewModel.toggleAttend(event.id) },
+                                    enabled = !eventDetailState.isAttendingLoading,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    if (eventDetailState.isAttendingLoading) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(16.dp),
+                                            strokeWidth = 2.dp,
+                                            color = MaterialTheme.colorScheme.onPrimary
+                                        )
+                                    } else {
+                                        Text("Attend")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    item {
                         val attendeeCount = event.attendeeCount.takeIf { it > 0 } ?: event.attendeeIds?.size ?: eventDetailState.attendees.size
                         Text(
                             text = "Attendees ($attendeeCount)",
@@ -728,25 +779,46 @@ fun ForumEventDetailContent(
                         )
                     }
                     items(items = eventDetailState.attendees, key = { it.id ?: it.username ?: "" }) { attendee ->
+                        val ctx = LocalContext.current
+                        var imageLoadFailed by remember { mutableStateOf(false) }
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(vertical = 4.dp),
+                                .clip(MaterialTheme.shapes.small)
+                                .clickable(enabled = attendee.id != null) { attendee.id?.let { id -> onOpenUserProfile(id) } }
+                                .padding(vertical = 6.dp, horizontal = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
-                            Box(
-                                modifier = Modifier
-                                    .size(36.dp)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primaryContainer),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = forumUserInitials(attendee),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                            val initial = (attendee.username ?: attendee.fullName ?: "?")
+                                .trim().firstOrNull()?.uppercase() ?: "?"
+                            if (!attendee.profilePicture.isNullOrBlank() && !imageLoadFailed) {
+                                AsyncImage(
+                                    model = ImageRequest.Builder(ctx)
+                                        .data(attendee.profilePicture)
+                                        .crossfade(true)
+                                        .build(),
+                                    contentDescription = attendee.username,
+                                    contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                                    onError = { imageLoadFailed = true },
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
                                 )
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.primaryContainer),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = initial,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                }
                             }
                             Text(
                                 text = attendee.fullName?.takeIf { it.isNotBlank() } ?: attendee.username ?: "User",

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ForumViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ForumViewModel.kt
@@ -6,6 +6,7 @@ import com.hive.hive_app.data.api.dto.ForumCommentResponse
 import com.hive.hive_app.data.api.dto.ForumDiscussionResponse
 import com.hive.hive_app.data.api.dto.ForumEventResponse
 import com.hive.hive_app.data.api.dto.ForumUserEmbed
+import com.hive.hive_app.data.repository.AuthRepository
 import com.hive.hive_app.data.repository.ForumRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +20,8 @@ enum class ForumTab { DISCUSSIONS, EVENTS }
 
 @HiltViewModel
 class ForumViewModel @Inject constructor(
-    private val forumRepository: ForumRepository
+    private val forumRepository: ForumRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     data class ForumListState(
@@ -64,7 +66,9 @@ class ForumViewModel @Inject constructor(
         val attendees: List<ForumUserEmbed> = emptyList(),
         val isLoading: Boolean = false,
         val commentsLoading: Boolean = false,
-        val error: String? = null
+        val error: String? = null,
+        val currentUserId: String? = null,
+        val isAttendingLoading: Boolean = false
     )
 
     data class CreateEventState(
@@ -310,10 +314,16 @@ class ForumViewModel @Inject constructor(
     fun loadEvent(eventId: String) {
         viewModelScope.launch {
             _eventDetailState.update { it.copy(isLoading = true, error = null) }
+            val currentUserId = authRepository.getCurrentUser().getOrNull()?._id
             forumRepository.getEvent(eventId)
                 .onSuccess { event ->
                     _eventDetailState.update {
-                        it.copy(event = event, isLoading = false, error = null)
+                        it.copy(
+                            event = event,
+                            isLoading = false,
+                            error = null,
+                            currentUserId = currentUserId
+                        )
                     }
                     loadCommentsForEvent(eventId)
                     forumRepository.getEventAttendees(eventId).onSuccess { attendees ->
@@ -327,6 +337,30 @@ class ForumViewModel @Inject constructor(
                             error = e.message ?: "Failed to load event"
                         )
                     }
+                }
+        }
+    }
+
+    fun toggleAttend(eventId: String) {
+        val state = _eventDetailState.value
+        val currentUserId = state.currentUserId ?: return
+        val isAttending = state.event?.attendeeIds?.contains(currentUserId) == true
+        viewModelScope.launch {
+            _eventDetailState.update { it.copy(isAttendingLoading = true) }
+            val result = if (isAttending) {
+                forumRepository.unattendEvent(eventId)
+            } else {
+                forumRepository.attendEvent(eventId)
+            }
+            result
+                .onSuccess { updatedEvent ->
+                    _eventDetailState.update { it.copy(event = updatedEvent, isAttendingLoading = false) }
+                    forumRepository.getEventAttendees(eventId).onSuccess { attendees ->
+                        _eventDetailState.update { it.copy(attendees = attendees) }
+                    }
+                }
+                .onFailure {
+                    _eventDetailState.update { it.copy(isAttendingLoading = false) }
                 }
         }
     }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
@@ -115,17 +115,30 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 
+/** Typed payload stored in [Marker.relatedObject] so the InfoWindow can populate rich fields. */
+private data class MarkerPayload(
+    val navId: String,
+    val service: ServiceResponse? = null,
+    val event: ForumEventResponse? = null,
+    val creator: CreatorInfo? = null
+)
+
 /**
- * Bubble tap opens detail; empty-map tap closes via [MapEventsOverlay] (not MapView touch listener).
+ * Rich web-style popup InfoWindow.
  *
- * [BasicInfoWindow] installs [View.setOnTouchListener] in its constructor to close on ACTION_UP and
- * consume the event, which blocks [View.setOnClickListener]; clear it so bubble taps work.
+ * First tap on a marker opens this window.
+ * Tap "View Details" navigates to the detail screen.
+ * Tap "X" closes the window.
+ *
+ * [BasicInfoWindow] installs [View.setOnTouchListener] in its constructor; we clear it so
+ * the individual button click listeners work properly.
  */
 private class MapBubbleInfoWindow(
     layoutResId: Int,
     mapView: MapView,
-    private val onBubbleTap: (Marker) -> Unit
+    private val onViewDetails: (Marker) -> Unit
 ) : BasicInfoWindow(layoutResId, mapView) {
+
     init {
         mView.setOnTouchListener(null)
     }
@@ -133,7 +146,160 @@ private class MapBubbleInfoWindow(
     override fun onOpen(item: Any?) {
         super.onOpen(item)
         val marker = item as? Marker ?: return
-        mView.setOnClickListener { onBubbleTap(marker) }
+        val payload = marker.relatedObject as? MarkerPayload
+        val ctx = mView.context
+
+        // Force fixed width — osmdroid can override XML layout_width
+        val widthPx = (300 * ctx.resources.displayMetrics.density + 0.5f).toInt()
+        mView.minimumWidth = widthPx
+        mView.layoutParams = mView.layoutParams?.also { it.width = widthPx }
+            ?: android.view.ViewGroup.LayoutParams(widthPx, android.view.ViewGroup.LayoutParams.WRAP_CONTENT)
+        mView.requestLayout()
+
+        mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_close_btn)
+            ?.setOnClickListener { close() }
+
+        mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_view_details)
+            ?.setOnClickListener { onViewDetails(marker) }
+
+        val typeBadge = mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_type_badge)
+        val durationBadge = mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_duration_badge)
+        val tagsScroll = mView.findViewById<android.widget.HorizontalScrollView>(com.hive.hive_app.R.id.bubble_tags_scroll)
+        val tagsRow = mView.findViewById<android.widget.LinearLayout>(com.hive.hive_app.R.id.bubble_tags_row)
+        val dateView = mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_date)
+
+        fun dpToPx(dp: Int): Int = (dp * ctx.resources.displayMetrics.density + 0.5f).toInt()
+
+        fun populateTags(tags: List<com.hive.hive_app.data.api.dto.TagDto>, chipBgRes: Int, chipTextColor: Int) {
+            tagsRow?.removeAllViews()
+            val validTags = tags.take(4).mapNotNull { tag ->
+                (tag.label ?: tag.name ?: tag.entityId ?: tag.id)?.takeIf { it.isNotBlank() }
+            }
+            if (validTags.isEmpty()) {
+                tagsScroll?.visibility = android.view.View.GONE
+                return
+            }
+            validTags.forEach { label ->
+                val chip = android.widget.TextView(ctx).apply {
+                    text = label
+                    textSize = 11f
+                    setTextColor(chipTextColor)
+                    setPadding(dpToPx(8), dpToPx(3), dpToPx(8), dpToPx(3))
+                    setBackgroundResource(chipBgRes)
+                    val lp = android.widget.LinearLayout.LayoutParams(
+                        android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
+                        android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+                    )
+                    lp.marginEnd = dpToPx(6)
+                    layoutParams = lp
+                }
+                tagsRow?.addView(chip)
+            }
+            tagsScroll?.visibility = android.view.View.VISIBLE
+        }
+
+        val usernameView = mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_username)
+        val ratingView = mView.findViewById<android.widget.TextView>(com.hive.hive_app.R.id.bubble_rating)
+
+        val userSection = mView.findViewById<android.widget.LinearLayout>(com.hive.hive_app.R.id.bubble_user_section)
+
+        fun populateCreator(creator: CreatorInfo?) {
+            val name = creator?.user?.username ?: creator?.user?.fullName
+            val avg = creator?.rating
+            if (name != null || avg != null) {
+                userSection?.visibility = android.view.View.VISIBLE
+                if (name != null) {
+                    usernameView?.text = name
+                    usernameView?.visibility = android.view.View.VISIBLE
+                } else {
+                    usernameView?.visibility = android.view.View.GONE
+                }
+                if (avg != null) {
+                    ratingView?.text = "★ ${"%.1f".format(avg)}"
+                    ratingView?.visibility = android.view.View.VISIBLE
+                } else {
+                    ratingView?.visibility = android.view.View.GONE
+                }
+            } else {
+                userSection?.visibility = android.view.View.GONE
+            }
+        }
+
+        fun formatDate(isoString: String, pattern: String): String? =
+            runCatching {
+                Instant.parse(isoString)
+                    .atZone(ZoneId.systemDefault())
+                    .format(DateTimeFormatter.ofPattern(pattern, java.util.Locale.ENGLISH))
+            }.getOrElse {
+                runCatching {
+                    java.time.LocalDate.parse(isoString.take(10))
+                        .atStartOfDay(ZoneId.systemDefault())
+                        .format(DateTimeFormatter.ofPattern(pattern, java.util.Locale.ENGLISH))
+                }.getOrNull()
+            }
+
+        when {
+            payload?.service != null -> {
+                val svc = payload.service
+                val isOffer = svc.serviceType == "offer"
+                typeBadge?.text = if (isOffer) "Offer" else "Need"
+                typeBadge?.setBackgroundResource(
+                    if (isOffer) com.hive.hive_app.R.drawable.map_badge_bg_offer
+                    else com.hive.hive_app.R.drawable.map_badge_bg_need
+                )
+                val dur = svc.estimatedDuration.toInt()
+                durationBadge?.text = "${dur}h"
+                durationBadge?.visibility = android.view.View.VISIBLE
+
+                populateTags(
+                    svc.tags,
+                    com.hive.hive_app.R.drawable.map_tag_chip_bg,
+                    android.graphics.Color.parseColor("#4A148C")
+                )
+
+                val rawDate = svc.specificDate ?: svc.createdAt
+                val dateLabel = if (svc.specificDate != null) "Date" else "Posted"
+                val fmt = formatDate(rawDate, "d MMMM yyyy")
+                if (fmt != null) {
+                    dateView?.text = "$dateLabel: $fmt"
+                    dateView?.visibility = android.view.View.VISIBLE
+                } else {
+                    dateView?.visibility = android.view.View.GONE
+                }
+                populateCreator(payload.creator)
+            }
+
+            payload?.event != null -> {
+                val ev = payload.event
+                typeBadge?.text = "Event"
+                typeBadge?.setBackgroundResource(com.hive.hive_app.R.drawable.map_badge_bg_event)
+
+                val dateBadge = formatDate(ev.eventAt, "MMM d, HH:mm")
+                durationBadge?.text = dateBadge ?: ""
+                durationBadge?.visibility = if (dateBadge != null) android.view.View.VISIBLE else android.view.View.GONE
+
+                populateTags(
+                    ev.tags ?: emptyList(),
+                    com.hive.hive_app.R.drawable.map_tag_chip_bg_event,
+                    android.graphics.Color.parseColor("#5B21B6")
+                )
+
+                val evDate = formatDate(ev.eventAt, "d MMMM yyyy, HH:mm")
+                if (evDate != null) {
+                    dateView?.text = "Date: $evDate"
+                    dateView?.visibility = android.view.View.VISIBLE
+                } else {
+                    dateView?.visibility = android.view.View.GONE
+                }
+                populateCreator(payload.creator)
+            }
+
+            else -> {
+                durationBadge?.visibility = android.view.View.GONE
+                tagsScroll?.visibility = android.view.View.GONE
+                dateView?.visibility = android.view.View.GONE
+            }
+        }
     }
 
     override fun onClose() {
@@ -524,18 +690,14 @@ fun MapScreen(
                     map.overlays.add(privacyRadiusPolygon(lat, lon, density, MapMarkerKind.EVENT))
                 }
                 fun openDetailForServiceOrEventMarker(marker: Marker) {
-                    when (val rel = marker.relatedObject as? String) {
-                        null -> { }
-                        else -> {
-                            when {
-                                rel.startsWith("service:") -> {
-                                    val id = rel.removePrefix("service:")
-                                    if (onServiceSelected != null) onServiceSelected(id) else selectedServiceId = id
-                                }
-                                rel.startsWith("event:") -> {
-                                    selectedForumEventId = rel.removePrefix("event:")
-                                }
-                            }
+                    val payload = marker.relatedObject as? MarkerPayload ?: return
+                    when {
+                        payload.navId.startsWith("service:") -> {
+                            val id = payload.navId.removePrefix("service:")
+                            if (onServiceSelected != null) onServiceSelected(id) else selectedServiceId = id
+                        }
+                        payload.navId.startsWith("event:") -> {
+                            selectedForumEventId = payload.navId.removePrefix("event:")
                         }
                     }
                     InfoWindow.closeAllInfoWindowsOn(map)
@@ -548,14 +710,13 @@ fun MapScreen(
                     service.location ?: return@forEach
                     val markerKind = if (service.serviceType == "offer") MapMarkerKind.OFFER else MapMarkerKind.NEED
                     val icon = markerIcon(markerKind)
-                    val tagsText = service.tags.joinToString(", ") { it.label ?: it.name ?: "" }.takeIf { it.isNotBlank() } ?: ""
                     val marker = Marker(map).apply {
                         position = GeoPoint(service.location.latitude, service.location.longitude)
                         setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                         setIcon(icon)
                         title = service.title
-                        snippet = tagsText
-                        relatedObject = "service:${service._id}"
+                        snippet = ""
+                        relatedObject = MarkerPayload("service:${service._id}", service = service, creator = state.creatorInfo[service.userId])
                         setInfoWindow(bubbleWindow)
                         setOnMarkerClickListener { m, _ ->
                             val sameMarkerOpen =
@@ -563,6 +724,8 @@ fun MapScreen(
                             if (sameMarkerOpen) {
                                 openDetailForServiceOrEventMarker(m)
                             } else {
+                                InfoWindow.closeAllInfoWindowsOn(map)
+                                map.controller.animateTo(m.position)
                                 m.showInfoWindow()
                             }
                             true
@@ -573,16 +736,13 @@ fun MapScreen(
                 mapEvents.forEach { event ->
                     val lat = event.latitude ?: return@forEach
                     val lon = event.longitude ?: return@forEach
-                    val tagsText = event.tags?.joinToString(", ") { it.label ?: it.name ?: "" }
-                        ?.takeIf { it.isNotBlank() }
-                        ?: ""
                     val marker = Marker(map).apply {
                         position = GeoPoint(lat, lon)
                         setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                         setIcon(markerIcon(MapMarkerKind.EVENT))
                         title = event.title
-                        snippet = tagsText
-                        relatedObject = "event:${event.id}"
+                        snippet = ""
+                        relatedObject = MarkerPayload("event:${event.id}", event = event, creator = event.userId?.let { state.creatorInfo[it] })
                         setInfoWindow(bubbleWindow)
                         setOnMarkerClickListener { m, _ ->
                             val sameMarkerOpen =
@@ -590,6 +750,8 @@ fun MapScreen(
                             if (sameMarkerOpen) {
                                 openDetailForServiceOrEventMarker(m)
                             } else {
+                                InfoWindow.closeAllInfoWindowsOn(map)
+                                map.controller.animateTo(m.position)
                                 m.showInfoWindow()
                             }
                             true

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/MapViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/MapViewModel.kt
@@ -13,7 +13,10 @@ import androidx.lifecycle.viewModelScope
 import com.hive.hive_app.data.api.dto.ForumEventResponse
 import com.hive.hive_app.data.api.dto.ServiceResponse
 import com.hive.hive_app.data.repository.ForumRepository
+import com.hive.hive_app.data.repository.RatingsRepository
 import com.hive.hive_app.data.repository.ServicesRepository
+import com.hive.hive_app.data.repository.UsersRepository
+import com.hive.hive_app.util.getHighestPriorityBadge
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.Instant
@@ -38,6 +41,8 @@ import kotlin.math.sqrt
 class MapViewModel @Inject constructor(
     private val servicesRepository: ServicesRepository,
     private val forumRepository: ForumRepository,
+    private val usersRepository: UsersRepository,
+    private val ratingsRepository: RatingsRepository,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -86,7 +91,8 @@ class MapViewModel @Inject constructor(
         val visibleEvents: List<ForumEventResponse> = emptyList(),
         val isLoading: Boolean = false,
         val error: String? = null,
-        val locationPermissionGranted: Boolean = false
+        val locationPermissionGranted: Boolean = false,
+        val creatorInfo: Map<String, CreatorInfo> = emptyMap()
     )
 
     private val _state = MutableStateFlow(MapState())
@@ -175,7 +181,8 @@ class MapViewModel @Inject constructor(
                 tags = s.filterTag?.takeIf { it.isNotBlank() },
                 latitude = null,
                 longitude = null,
-                radius = null
+                radius = null,
+                serviceStatus = "active"
             )
             result.fold(
                 onSuccess = { listResponse ->
@@ -200,6 +207,7 @@ class MapViewModel @Inject constructor(
                         error = null
                     )
                     recomputeVisible()
+                    loadCreatorInfo(list.map { it.userId }.distinct())
                 },
                 onFailure = {
                     _state.value = _state.value.copy(
@@ -208,6 +216,27 @@ class MapViewModel @Inject constructor(
                     )
                 }
             )
+        }
+    }
+
+    private fun loadCreatorInfo(userIds: List<String>) {
+        if (userIds.isEmpty()) return
+        viewModelScope.launch {
+            val map = mutableMapOf<String, CreatorInfo>()
+            userIds.forEach { userId ->
+                val user = usersRepository.getUser(userId).getOrNull()
+                val rating = ratingsRepository.getUserRatings(userId).getOrNull()?.averageScore
+                val badgesResponse = usersRepository.getUserBadges(userId).getOrNull()
+                val topBadge = getHighestPriorityBadge(badgesResponse?.badges)
+                map[userId] = CreatorInfo(
+                    user = user,
+                    rating = rating,
+                    primaryBadgeKey = topBadge?.key,
+                    primaryBadgeName = topBadge?.name,
+                    primaryBadgeDescription = topBadge?.description
+                )
+            }
+            _state.update { it.copy(creatorInfo = it.creatorInfo + map) }
         }
     }
 

--- a/app/app/src/main/res/drawable/map_badge_bg_event.xml
+++ b/app/app/src/main/res/drawable/map_badge_bg_event.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#7C3AED" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_badge_bg_need.xml
+++ b/app/app/src/main/res/drawable/map_badge_bg_need.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#D97706" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_badge_bg_neutral.xml
+++ b/app/app/src/main/res/drawable/map_badge_bg_neutral.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E7E5E4" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_badge_bg_offer.xml
+++ b/app/app/src/main/res/drawable/map_badge_bg_offer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#059669" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_btn_view_details_bg.xml
+++ b/app/app/src/main/res/drawable/map_btn_view_details_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#84CC16" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_tag_chip_bg.xml
+++ b/app/app/src/main/res/drawable/map_tag_chip_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E8E0F5" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/drawable/map_tag_chip_bg_event.xml
+++ b/app/app/src/main/res/drawable/map_tag_chip_bg_event.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#EDE9FE" />
+    <corners android:radius="100dp" />
+</shape>

--- a/app/app/src/main/res/layout/map_info_window.xml
+++ b/app/app/src/main/res/layout/map_info_window.xml
@@ -1,38 +1,175 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/bubble_main"
-    android:layout_width="wrap_content"
+    android:layout_width="300dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
     android:background="@drawable/map_info_window_bg"
-    android:elevation="0dp"
+    android:elevation="8dp"
     android:orientation="vertical"
-    android:padding="12dp"
-    android:minWidth="120dp">
+    android:padding="14dp">
 
+    <!-- Top row: [Type badge | Duration chip]  ...  [Username ★Rating] [X] -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+
+        <!-- Left: type + duration badges -->
+        <LinearLayout
+            android:id="@+id/bubble_badges_row"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true">
+
+            <TextView
+                android:id="@+id/bubble_type_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/map_badge_bg_offer"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:textColor="@color/white"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:text="Offer" />
+
+            <TextView
+                android:id="@+id/bubble_duration_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:background="@drawable/map_badge_bg_neutral"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:textColor="#57534E"
+                android:textSize="11sp"
+                android:text="1h"
+                android:visibility="gone" />
+
+        </LinearLayout>
+
+        <!-- Right: close button -->
+        <TextView
+            android:id="@+id/bubble_close_btn"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:gravity="center"
+            android:text="&#x2715;"
+            android:textColor="#78716C"
+            android:textSize="14sp"
+            android:clickable="true"
+            android:focusable="true" />
+
+        <!-- Middle-right: username + rating (hidden when no data) -->
+        <LinearLayout
+            android:id="@+id/bubble_user_section"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_toStartOf="@id/bubble_close_btn"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="6dp"
+            android:gravity="center_vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/bubble_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/on_surface"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:maxWidth="80dp" />
+
+            <TextView
+                android:id="@+id/bubble_rating"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:textColor="#B45309"
+                android:textSize="11sp"
+                android:visibility="gone" />
+
+        </LinearLayout>
+
+    </RelativeLayout>
+
+    <!-- Title -->
     <TextView
         android:id="@+id/bubble_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/on_surface"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:maxLines="2"
+        android:layout_marginBottom="8dp" />
+
+    <!-- Tags (chips added programmatically) -->
+    <HorizontalScrollView
+        android:id="@+id/bubble_tags_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:layout_marginBottom="6dp"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:id="@+id/bubble_tags_row"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
+
+    </HorizontalScrollView>
+
+    <!-- Date -->
+    <TextView
+        android:id="@+id/bubble_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/on_surface_variant"
+        android:textSize="12sp"
+        android:layout_marginBottom="12dp"
+        android:visibility="gone" />
+
+    <!-- View Details button -->
+    <TextView
+        android:id="@+id/bubble_view_details"
+        android:layout_width="match_parent"
+        android:layout_height="42dp"
+        android:background="@drawable/map_btn_view_details_bg"
+        android:gravity="center"
+        android:text="View Details"
         android:textColor="@color/on_surface"
         android:textSize="14sp"
         android:textStyle="bold"
-        android:maxWidth="200dp" />
+        android:clickable="true"
+        android:focusable="true" />
 
+    <!-- Hidden views required by BasicInfoWindow -->
     <TextView
         android:id="@+id/bubble_description"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:textColor="@color/on_surface_variant"
-        android:textSize="12sp"
-        android:maxWidth="200dp" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/bubble_subdescription"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:visibility="gone" />
 
     <ImageView
@@ -40,4 +177,5 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone" />
+
 </LinearLayout>

--- a/frontend/src/components/map/ServiceMap.tsx
+++ b/frontend/src/components/map/ServiceMap.tsx
@@ -497,7 +497,7 @@ function ServicePopupContent({
 
   const formatDate = (dateStr?: string) => {
     if (!dateStr) return null;
-    return new Date(dateStr).toLocaleDateString(undefined, {
+    return new Date(dateStr).toLocaleDateString("en-GB", {
       year: "numeric",
       month: "long",
       day: "numeric",
@@ -607,7 +607,7 @@ function EventPopupContent({ event }: { event: ForumEvent }) {
           Event
         </Badge>
         <Badge color="gray" variant="soft" size="1">
-          {new Date(event.event_at).toLocaleDateString(undefined, {
+          {new Date(event.event_at).toLocaleDateString("en-GB", {
             month: "short",
             day: "numeric",
             hour: "2-digit",
@@ -622,15 +622,6 @@ function EventPopupContent({ event }: { event: ForumEvent }) {
           Linked: {event.service.title}
         </Badge>
       )}
-      <div className="flex items-center gap-2 w-full">
-        <Button
-          variant="soft"
-          className="flex-1"
-          onClick={() => navigate(`/forum/events/${event._id}`)}
-        >
-          View Event
-        </Button>
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Forum.tsx
+++ b/frontend/src/pages/Forum.tsx
@@ -44,7 +44,7 @@ function timeAgo(dateStr: string) {
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
+  return new Date(dateStr).toLocaleDateString("en-GB");
 }
 export function Forum() {
   const navigate = useNavigate();
@@ -295,7 +295,7 @@ export function Forum() {
                     <Flex gap="2" align="center">
                       <Badge size="1" variant="soft" color="purple">
                         <CalendarClockIcon className="w-3 h-3" />
-                        {new Date(ev.event_at).toLocaleDateString(undefined, {
+                        {new Date(ev.event_at).toLocaleDateString("en-GB", {
                           month: "short",
                           day: "numeric",
                           year: "numeric",
@@ -687,3 +687,4 @@ function NewEventDialog({
     </Dialog.Root>
   );
 }
+                                                                                                                                                                                         


### PR DESCRIPTION
- Add attend/unattend endpoints and repository methods

- Show Attend/Leave button on event detail (hidden for organizer)

- Display attendees with profile pictures, fallback to initials

- Clicking an attendee navigates to their profile

- Redesign map info window with type badge, tags, date, creator info

- Center map on marker tap and close previous popup automatically

- Filter out inactive services from map (serviceStatus=active)

- Bump version to 1.1.6 (versionCode 6)