### PR TITLE
Implement image listing UI for events and services

### DIFF
--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -102,3 +102,15 @@ async def upload_comment_image(
     filename = f"{uuid.uuid4().hex}{ext}"
     url = _save_upload(file, "comments", filename)
     return {"url": url}
+
+
+@router.post("/forum-event-image")
+async def upload_forum_event_image(
+    file: UploadFile = File(...),
+    current_user: UserResponse = Depends(get_current_user),
+):
+    """Upload an image for a forum event. Returns the URL."""
+    ext = _validate_image(file)
+    filename = f"{uuid.uuid4().hex}{ext}"
+    url = _save_upload(file, "forum-events", filename)
+    return {"url": url}

--- a/backend/app/models/forum.py
+++ b/backend/app/models/forum.py
@@ -98,6 +98,7 @@ class ForumEventCreate(BaseModel):
     is_remote: bool = False
     tags: List[dict] = Field(default_factory=list, max_length=10)
     service_id: Optional[str] = None
+    image_urls: Optional[List[str]] = None
 
     @model_validator(mode='before')
     @classmethod
@@ -128,6 +129,7 @@ class ForumEventUpdate(BaseModel):
     is_remote: Optional[bool] = None
     tags: Optional[List[dict]] = Field(None, max_length=10)
     service_id: Optional[str] = None
+    image_urls: Optional[List[str]] = None
 
     class Config:
         json_encoders = {ObjectId: str}
@@ -154,6 +156,7 @@ class ForumEventResponse(BaseModel):
     attendee_count: int = 0
     upvote_count: int = 0
     user_upvoted: bool = False
+    image_urls: List[str] = Field(default_factory=list)
 
     class Config:
         populate_by_name = True

--- a/frontend/src/components/ui/OfferListingCard.tsx
+++ b/frontend/src/components/ui/OfferListingCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Badge, Text, Flex } from "@radix-ui/themes";
+import { Card, Badge, Text, Flex, Inset } from "@radix-ui/themes";
 import { Service, BadgeSummary } from "@/types";
 import { useNavigate } from "react-router-dom";
 import { ClickableTag } from "@/components/ui/ClickableTag";
@@ -11,10 +11,14 @@ import {
 } from "@radix-ui/react-icons";
 import { CalendarIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { usersApi, ratingsApi } from "@/services/api";
+import { usersApi, ratingsApi, getImageUrl } from "@/services/api";
 import { StatusBadge } from "./StatusBadge";
 import { CustomBadge, getHighestPriorityBadge } from "./BadgeDisplay";
-import { formatRelativeTime, formatDurationShort, formatDateShort } from "@/utils/utils";
+import {
+  formatRelativeTime,
+  formatDurationShort,
+  formatDateShort,
+} from "@/utils/utils";
 import { useSavedServiceIds } from "@/hooks/useSavedServiceIds";
 
 interface OfferListingCardProps {
@@ -59,7 +63,8 @@ export function OfferListingCard({
             data: { total: 0, average_score: null },
           })),
         ]);
-        const earnedBadges = badgesRes.data?.badges.filter((b) => b.earned) ?? [];
+        const earnedBadges =
+          badgesRes.data?.badges.filter((b) => b.earned) ?? [];
         setUser(userRes.data);
         setBadgeSummary({
           badges: badgesRes.data?.badges ?? [],
@@ -133,13 +138,31 @@ export function OfferListingCard({
   return (
     <Card
       size="2"
-      className={`hover-card flex flex-col h-full gap-2 overflow-hidden ${
+      className={`offer-listing-card hover-card flex flex-col h-full gap-2 overflow-hidden ${
         isRecommended ? "recommended-listing-card" : ""
       }`}
       onClick={handleCardClick}
     >
+      {service.image_urls && service.image_urls.length > 0 && (
+        <Inset clip="padding-box" side="top" pb="current" className="p-[1px]">
+          <img
+            src={getImageUrl(service.image_urls[0]) ?? service.image_urls[0]}
+            alt={service.title}
+            loading="lazy"
+            style={{
+              display: "block",
+              objectFit: "cover",
+              width: "100%",
+              height: 160,
+              backgroundColor: "var(--gray-5)",
+            }}
+          />
+        </Inset>
+      )}
       {/* Header with status badges (left) and user info (right) */}
-      <div className={`flex gap-2 ${isRecommended ? "flex-col" : "items-center justify-between"}`}>
+      <div
+        className={`flex gap-2 ${isRecommended ? "flex-col" : "items-center justify-between"}`}
+      >
         {isRecommended && (
           <Text size="1" className="recommended-listing-label">
             Recommended
@@ -183,19 +206,23 @@ export function OfferListingCard({
             </Text>
           </Flex>
         )}
-        {service.scheduling_type === "recurring" && service.recurring_pattern && (
-          <Flex align="center" gap="1">
-            <CalendarIcon className="w-5 h-5 text-blue-500" />
-            <Text>
-              {service.recurring_pattern.days.join(", ")}
-              {service.recurring_pattern.time && ` · ${service.recurring_pattern.time}`}
-            </Text>
-          </Flex>
-        )}
+        {service.scheduling_type === "recurring" &&
+          service.recurring_pattern && (
+            <Flex align="center" gap="1">
+              <CalendarIcon className="w-5 h-5 text-blue-500" />
+              <Text>
+                {service.recurring_pattern.days.join(", ")}
+                {service.recurring_pattern.time &&
+                  ` · ${service.recurring_pattern.time}`}
+              </Text>
+            </Flex>
+          )}
         {service.scheduling_type === "open" && service.open_availability && (
           <Flex align="center" gap="1">
             <CalendarIcon className="w-5 h-5 text-blue-500" />
-            <Text className="truncate max-w-[200px]">{service.open_availability}</Text>
+            <Text className="truncate max-w-[200px]">
+              {service.open_availability}
+            </Text>
           </Flex>
         )}
       </Flex>
@@ -233,7 +260,8 @@ export function OfferListingCard({
       <div className="flex items-center justify-between">
         <Text size="1" className="opacity-60">
           Posted {formatRelativeTime(service.created_at)}
-          {service.deadline && ` | Deadline: ${formatRelativeTime(service.deadline)}`}
+          {service.deadline &&
+            ` | Deadline: ${formatRelativeTime(service.deadline)}`}
         </Text>
         {currentUserId && (
           <Badge

--- a/frontend/src/pages/Forum.tsx
+++ b/frontend/src/pages/Forum.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Flex,
   Heading,
+  Inset,
   Tabs,
   Text,
   TextField,
@@ -26,7 +27,7 @@ import {
 } from "@radix-ui/react-icons";
 import { UpvoteButton } from "@/components/ui/UpvoteButton";
 import { MessageCircleIcon, CalendarClockIcon } from "lucide-react";
-import { forumApi, getImageUrl } from "@/services/api";
+import { forumApi, getImageUrl, uploadApi } from "@/services/api";
 import { ForumDiscussion, ForumEvent, TagEntity } from "@/types";
 import { TagAutocomplete } from "@/components/forms/TagAutocomplete";
 import { ClickableTag } from "@/components/ui/ClickableTag";
@@ -59,8 +60,12 @@ export function Forum() {
   const [events, setEvents] = useState<ForumEvent[]>([]);
   const [eventsTotal, setEventsTotal] = useState(0);
   const [eventsLoading, setEventsLoading] = useState(true);
-  const [discussionSort, setDiscussionSort] = useState<"created_at" | "upvote_count">("created_at");
-  const [eventSort, setEventSort] = useState<"event_at" | "upvote_count" | "created_at">("event_at");
+  const [discussionSort, setDiscussionSort] = useState<
+    "created_at" | "upvote_count"
+  >("created_at");
+  const [eventSort, setEventSort] = useState<
+    "event_at" | "upvote_count" | "created_at"
+  >("event_at");
   const [showNewDiscussion, setShowNewDiscussion] = useState(false);
   const [showNewEvent, setShowNewEvent] = useState(false);
   useEffect(() => {
@@ -115,7 +120,11 @@ export function Forum() {
         setDiscussionsTotal(r.data.total);
       });
     forumApi
-      .getEvents({ q: searchQ || undefined, tag: tagFilter || undefined, sort_by: eventSort })
+      .getEvents({
+        q: searchQ || undefined,
+        tag: tagFilter || undefined,
+        sort_by: eventSort,
+      })
       .then((r) => {
         setEvents(r.data.events);
         setEventsTotal(r.data.total);
@@ -160,13 +169,16 @@ export function Forum() {
             {discussionsTotal})
           </Tabs.Trigger>
           <Tabs.Trigger value="events">
-            <CalendarClockIcon className="mr-1 w-4 h-4" /> Events ({eventsTotal})
+            <CalendarClockIcon className="mr-1 w-4 h-4" /> Events ({eventsTotal}
+            )
           </Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="discussions" className="pt-4">
           <Flex justify="between" align="center" className="mb-4">
             <Flex gap="2" align="center">
-              <Text size="2" color="gray">Sort:</Text>
+              <Text size="2" color="gray">
+                Sort:
+              </Text>
               <Button
                 size="1"
                 variant={discussionSort === "created_at" ? "solid" : "soft"}
@@ -195,7 +207,7 @@ export function Forum() {
               <Text color="gray">No discussions yet. Start one!</Text>
             </Card>
           ) : (
-            <div className="space-y-3">
+            <div className="grid gap-4">
               {discussions.map((d) => (
                 <Card
                   key={d._id}
@@ -225,21 +237,21 @@ export function Forum() {
                         </Text>
                       </Flex>
                       <div className="mt-1 prose-content card-description">
-	                        <ReactMarkdown
-	                          components={{
-	                            a: ({ node: _node, ...props }) => (
-	                              <a
-	                                {...props}
-	                                target="_blank"
-	                                rel="noopener noreferrer"
-	                              >
-	                                {props.children}
-	                              </a>
-	                            ),
-	                          }}
-	                        >
-	                          {d.body}
-	                        </ReactMarkdown>
+                        <ReactMarkdown
+                          components={{
+                            a: ({ node: _node, ...props }) => (
+                              <a
+                                {...props}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {props.children}
+                              </a>
+                            ),
+                          }}
+                        >
+                          {d.body}
+                        </ReactMarkdown>
                       </div>
                       <Flex gap="2" align="center" className="mt-2" wrap="wrap">
                         <Text size="1" color="gray">
@@ -250,7 +262,10 @@ export function Forum() {
                           <MessageCircleIcon className="w-3 h-3 mr-1" />
                           {d.comment_count}
                         </Badge>
-                        <UpvoteButton count={d.upvote_count ?? 0} upvoted={d.user_upvoted} />
+                        <UpvoteButton
+                          count={d.upvote_count ?? 0}
+                          upvoted={d.user_upvoted}
+                        />
                         {(d.tags || []).slice(0, 3).map((tag, i) => (
                           <ClickableTag
                             key={i}
@@ -270,7 +285,9 @@ export function Forum() {
         <Tabs.Content value="events" className="pt-4">
           <Flex justify="between" align="center" className="mb-4">
             <Flex gap="2" align="center">
-              <Text size="2" color="gray">Sort:</Text>
+              <Text size="2" color="gray">
+                Sort:
+              </Text>
               <Button
                 size="1"
                 variant={eventSort === "event_at" ? "solid" : "soft"}
@@ -306,7 +323,7 @@ export function Forum() {
               <Text color="gray">No events yet. Create one!</Text>
             </Card>
           ) : (
-            <div className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {events.map((ev) => (
                 <Card
                   key={ev._id}
@@ -314,6 +331,22 @@ export function Forum() {
                   size="3"
                   onClick={() => navigate(`/forum/events/${ev._id}`)}
                 >
+                  {ev.image_urls && ev.image_urls.length > 0 && (
+                    <Inset clip="padding-box" side="top" pb="current">
+                      <img
+                        src={getImageUrl(ev.image_urls[0]) ?? ev.image_urls[0]}
+                        alt={ev.title}
+                        loading="lazy"
+                        style={{
+                          display: "block",
+                          objectFit: "cover",
+                          width: "100%",
+                          height: 160,
+                          backgroundColor: "var(--gray-5)",
+                        }}
+                      />
+                    </Inset>
+                  )}
                   <Flex justify="between" align="start" wrap="wrap">
                     <Text size="3" weight="bold" className="line-clamp-1">
                       {ev.title}
@@ -332,20 +365,20 @@ export function Forum() {
                     </Flex>
                   </Flex>
                   <div className="prose-content card-description">
-	                    <ReactMarkdown
-	                      components={{
-	                        a: ({ node: _node, ...props }) => (
-	                          <a
-	                            {...props}
-	                            target="_blank"
-	                            rel="noopener noreferrer"
-	                          >
-	                            {props.children}
-	                          </a>
-	                        ),
-	                      }}
-	                    >
-	                      {ev.description}
+                    <ReactMarkdown
+                      components={{
+                        a: ({ node: _node, ...props }) => (
+                          <a
+                            {...props}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {props.children}
+                          </a>
+                        ),
+                      }}
+                    >
+                      {ev.description}
                     </ReactMarkdown>
                   </div>
                   <Flex gap="2" align="center" className="mt-2" wrap="wrap">
@@ -376,7 +409,10 @@ export function Forum() {
                       <MessageCircleIcon className="w-3 h-3 mr-1" />
                       {ev.comment_count}
                     </Badge>
-                    <UpvoteButton count={ev.upvote_count ?? 0} upvoted={ev.user_upvoted} />
+                    <UpvoteButton
+                      count={ev.upvote_count ?? 0}
+                      upvoted={ev.user_upvoted}
+                    />
                     {(ev.tags || []).slice(0, 3).map((tag, i) => (
                       <ClickableTag
                         key={i}
@@ -542,6 +578,9 @@ function NewEventDialog({
   const [serviceId, setServiceId] = useState("__none__");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [imageFiles, setImageFiles] = useState<File[]>([]);
+  const [imagePreviewUrls, setImagePreviewUrls] = useState<string[]>([]);
+  const [imageUploading, setImageUploading] = useState(false);
   const reset = () => {
     setTitle("");
     setDescription("");
@@ -552,14 +591,55 @@ function NewEventDialog({
     setTags([]);
     setServiceId("__none__");
     setError("");
+    imagePreviewUrls.forEach((url) => URL.revokeObjectURL(url));
+    setImageFiles([]);
+    setImagePreviewUrls([]);
+  };
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (imageFiles.length >= 3) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setError("Image must be under 5 MB");
+      return;
+    }
+    setError("");
+    setImageFiles((prev) => [...prev, file]);
+    setImagePreviewUrls((prev) => [...prev, URL.createObjectURL(file)]);
+    e.target.value = "";
+  };
+  const removeImage = (index: number) => {
+    URL.revokeObjectURL(imagePreviewUrls[index]);
+    setImageFiles((prev) => prev.filter((_, i) => i !== index));
+    setImagePreviewUrls((prev) => prev.filter((_, i) => i !== index));
   };
   const handleSubmit = async () => {
     if (!title.trim() || !description.trim() || !eventDate || !eventTime) {
       setError("Title, description, date, and time are required");
       return;
     }
+    if (imageFiles.length === 0) {
+      setError("Please upload at least one image for the event");
+      return;
+    }
     const eventAt = new Date(`${eventDate}T${eventTime}`).toISOString();
     setSubmitting(true);
+    const uploadedUrls: string[] = [];
+    if (imageFiles.length > 0) {
+      setImageUploading(true);
+      try {
+        for (const file of imageFiles) {
+          const res = await uploadApi.uploadForumEventImage(file);
+          uploadedUrls.push(res.data.url);
+        }
+      } catch (err: any) {
+        setError(err?.response?.data?.detail || "Image upload failed");
+        setImageUploading(false);
+        setSubmitting(false);
+        return;
+      }
+      setImageUploading(false);
+    }
     try {
       await forumApi.createEvent({
         title,
@@ -578,6 +658,7 @@ function NewEventDialog({
         tags,
         service_id:
           serviceId && serviceId !== "__none__" ? serviceId : undefined,
+        image_urls: uploadedUrls,
       });
       reset();
       onOpenChange(false);
@@ -688,6 +769,49 @@ function NewEventDialog({
               }
             />
           </Form.Field>
+          <Box className="space-y-2">
+            <Text size="2" weight="medium" className="block">
+              Event image *
+            </Text>
+            {imageFiles.length < 3 && (
+              <label className="cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  className="sr-only"
+                  disabled={imageUploading}
+                  onChange={handleImageChange}
+                />
+                <span className="flex items-center justify-center gap-2 border rounded-lg p-2 hover-card text-center cursor-pointer font-medium text-sm w-full">
+                  <PlusIcon className="w-4 h-4" />
+                  Add image (max 3)
+                </span>
+              </label>
+            )}
+            {imagePreviewUrls.length > 0 && (
+              <Flex gap="2" wrap="wrap" className="border rounded-lg p-2">
+                {imagePreviewUrls.map((url, i) => (
+                  <Box key={i} className="relative">
+                    <img
+                      src={url}
+                      alt={`Preview ${i + 1}`}
+                      className="rounded-lg object-cover h-24 w-24"
+                    />
+                    <Button
+                      type="button"
+                      size="1"
+                      variant="solid"
+                      color="red"
+                      className="!absolute top-1 right-1 !p-1 w-5 h-5 cursor-pointer"
+                      onClick={() => removeImage(i)}
+                    >
+                      ×
+                    </Button>
+                  </Box>
+                ))}
+              </Flex>
+            )}
+          </Box>
           {error && (
             <Text size="2" color="red">
               {error}
@@ -703,8 +827,12 @@ function NewEventDialog({
               Cancel
             </Button>
             <Form.Submit asChild>
-              <Button type="submit" disabled={submitting}>
-                {submitting ? "Creating..." : "Create Event"}
+              <Button type="submit" disabled={submitting || imageUploading}>
+                {imageUploading
+                  ? "Uploading..."
+                  : submitting
+                    ? "Creating..."
+                    : "Create Event"}
               </Button>
             </Form.Submit>
           </Flex>

--- a/frontend/src/pages/ForumEventDetail.tsx
+++ b/frontend/src/pages/ForumEventDetail.tsx
@@ -25,8 +25,9 @@ import {
   CheckCircledIcon,
   Pencil1Icon,
   TrashIcon,
+  PlusIcon,
 } from "@radix-ui/react-icons";
-import { forumApi, getImageUrl } from "@/services/api";
+import { forumApi, getImageUrl, uploadApi } from "@/services/api";
 import { ForumEvent, TagEntity } from "@/types";
 import { ClickableTag } from "@/components/ui/ClickableTag";
 import { UpvoteButton } from "@/components/ui/UpvoteButton";
@@ -212,6 +213,19 @@ export function ForumEventDetail() {
             </Badge>
           ) : null}
         </Flex>
+
+        {event.image_urls && event.image_urls.length > 0 && (
+          <div className="mb-4 flex gap-2 flex-wrap">
+            {event.image_urls.map((url, i) => (
+              <img
+                key={i}
+                src={getImageUrl(url) ?? url}
+                alt={`Event image ${i + 1}`}
+                className="rounded-lg object-cover h-48 w-auto max-w-full"
+              />
+            ))}
+          </div>
+        )}
 
         <div className="prose-content mb-4">
           <ReactMarkdown
@@ -401,6 +415,29 @@ function EditEventDialog({
   const [tags, setTags] = useState<TagEntity[]>(event.tags ?? []);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [existingImageUrls, setExistingImageUrls] = useState<string[]>(event.image_urls ?? []);
+  const [imageFiles, setImageFiles] = useState<File[]>([]);
+  const [imagePreviewUrls, setImagePreviewUrls] = useState<string[]>([]);
+  const [imageUploading, setImageUploading] = useState(false);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (existingImageUrls.length + imageFiles.length >= 3) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setError("Image must be under 5 MB");
+      return;
+    }
+    setError("");
+    setImageFiles((prev) => [...prev, file]);
+    setImagePreviewUrls((prev) => [...prev, URL.createObjectURL(file)]);
+    e.target.value = "";
+  };
+  const removeNewImage = (index: number) => {
+    URL.revokeObjectURL(imagePreviewUrls[index]);
+    setImageFiles((prev) => prev.filter((_, i) => i !== index));
+    setImagePreviewUrls((prev) => prev.filter((_, i) => i !== index));
+  };
 
   // Reset when event changes or dialog reopens
   useEffect(() => {
@@ -416,8 +453,13 @@ function EditEventDialog({
       });
       setIsRemote(event.is_remote);
       setTags(event.tags ?? []);
+      setExistingImageUrls(event.image_urls ?? []);
+      imagePreviewUrls.forEach((url) => URL.revokeObjectURL(url));
+      setImageFiles([]);
+      setImagePreviewUrls([]);
       setError("");
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, event]);
 
   const handleSubmit = async () => {
@@ -427,6 +469,22 @@ function EditEventDialog({
     }
     const eventAt = new Date(`${eventDate}T${eventTime}`).toISOString();
     setSubmitting(true);
+    const uploadedUrls: string[] = [];
+    if (imageFiles.length > 0) {
+      setImageUploading(true);
+      try {
+        for (const file of imageFiles) {
+          const res = await uploadApi.uploadForumEventImage(file);
+          uploadedUrls.push(res.data.url);
+        }
+      } catch (err: any) {
+        setError(err?.response?.data?.detail || "Image upload failed");
+        setImageUploading(false);
+        setSubmitting(false);
+        return;
+      }
+      setImageUploading(false);
+    }
     try {
       const res = await forumApi.updateEvent(event._id, {
         title,
@@ -443,6 +501,7 @@ function EditEventDialog({
             : locationValue.longitude,
         is_remote: isRemote,
         tags,
+        image_urls: [...existingImageUrls, ...uploadedUrls],
       });
       onUpdated(res.data);
       onOpenChange(false);
@@ -543,6 +602,74 @@ function EditEventDialog({
               }
             />
           </Form.Field>
+          <Box className="space-y-2">
+            <Text size="2" weight="medium" className="block">
+              Event images
+            </Text>
+            {existingImageUrls.length + imageFiles.length < 3 && (
+              <label className="cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  className="sr-only"
+                  disabled={imageUploading}
+                  onChange={handleImageChange}
+                />
+                <span className="flex items-center justify-center gap-2 border rounded-lg p-2 hover-card text-center cursor-pointer font-medium text-sm w-full">
+                  <PlusIcon className="w-4 h-4" />
+                  Add image (max 3)
+                </span>
+              </label>
+            )}
+            {existingImageUrls.length > 0 && (
+              <Flex gap="2" wrap="wrap" className="border rounded-lg p-2">
+                {existingImageUrls.map((url, i) => (
+                  <Box key={i} className="relative">
+                    <img
+                      src={getImageUrl(url) ?? url}
+                      alt={`Image ${i + 1}`}
+                      className="rounded-lg object-cover h-24 w-24"
+                    />
+                    <Button
+                      type="button"
+                      size="1"
+                      variant="solid"
+                      color="red"
+                      className="!absolute top-1 right-1 !p-1 w-5 h-5 cursor-pointer"
+                      onClick={() =>
+                        setExistingImageUrls((prev) => prev.filter((_, j) => j !== i))
+                      }
+                    >
+                      ×
+                    </Button>
+                  </Box>
+                ))}
+              </Flex>
+            )}
+            {imagePreviewUrls.length > 0 && (
+              <Flex gap="2" wrap="wrap" className="border rounded-lg p-2">
+                {imagePreviewUrls.map((url, i) => (
+                  <Box key={i} className="relative">
+                    <img
+                      src={url}
+                      alt={`New image ${i + 1}`}
+                      className="rounded-lg object-cover h-24 w-24"
+                    />
+                    <Button
+                      type="button"
+                      size="1"
+                      variant="solid"
+                      color="red"
+                      className="!absolute top-1 right-1 !p-1 w-5 h-5 cursor-pointer"
+                      onClick={() => removeNewImage(i)}
+                    >
+                      ×
+                    </Button>
+                  </Box>
+                ))}
+              </Flex>
+            )}
+          </Box>
           {error && (
             <Text size="2" color="red">
               {error}
@@ -558,8 +685,8 @@ function EditEventDialog({
               Cancel
             </Button>
             <Form.Submit asChild>
-              <Button type="submit" disabled={submitting}>
-                {submitting ? "Saving..." : "Save Changes"}
+              <Button type="submit" disabled={submitting || imageUploading}>
+                {imageUploading ? "Uploading..." : submitting ? "Saving..." : "Save Changes"}
               </Button>
             </Form.Submit>
           </Flex>

--- a/frontend/src/pages/MyTimebankTab.tsx
+++ b/frontend/src/pages/MyTimebankTab.tsx
@@ -1,4 +1,5 @@
 import { Card, Text, Flex, Badge, Box, Heading } from "@radix-ui/themes";
+import { Link } from "react-router-dom";
 import { TimeBankTransaction, TimeBankResponse } from "@/types";
 
 interface MyTimebankTabProps {
@@ -24,10 +25,20 @@ export function MyTimebankTab({
           {timebankData.transactions.map((transaction: TimeBankTransaction) => (
             <Card key={transaction.id} className="p-3">
               <Flex justify="between" align="center">
-                <div className="flex-1">
-                  <Text size="2" weight="medium" className="block mb-1">
-                    {transaction.description}
-                  </Text>
+                <div className="flex-1 flex flex-col gap-2">
+                  {transaction.service_id ? (
+                    <Link
+                      to={`/service/${transaction.service_id}`}
+                      className="text-sm font-medium hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {transaction.description}
+                    </Link>
+                  ) : (
+                    <Text size="2" weight="medium" className="block mb-1">
+                      {transaction.description}
+                    </Text>
+                  )}
                   <Text size="1" color="gray">
                     {new Date(transaction.created_at).toLocaleDateString(
                       "en-US",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -116,6 +116,16 @@ export const uploadApi = {
       }],
     });
   },
+  uploadForumEventImage: (file: File): Promise<AxiosResponse<{ url: string }>> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    return api.post('/upload/forum-event-image', formData, {
+      transformRequest: [(data: unknown, headers?: Record<string, string>) => {
+        if (headers) delete headers['Content-Type'];
+        return data;
+      }],
+    });
+  },
 };
 
 // Auth API

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -609,6 +609,7 @@ export interface ForumEvent {
   attendee_count: number;
   upvote_count: number;
   user_upvoted?: boolean;
+  image_urls?: string[];
 }
 
 export interface ForumEventListResponse {
@@ -628,6 +629,7 @@ export interface ForumEventForm {
   is_remote: boolean;
   tags: TagEntity[];
   service_id?: string;
+  image_urls?: string[];
 }
 
 export interface ForumComment {


### PR DESCRIPTION
- [For services] If image_urls is non-empty, display the first image as a card thumbnail. Graceful fallback (placeholder icon) when no image exists.
- If a transaction has an associated service_id, the service name in the description should render as a link to /services/:id. This lets users quickly audit what they paid for or earned from.
- Add endpoint for uploading forum event images.
- Update ForumEvent models to include image_urls.
- Modify Forum and ForumEventDetail components to display uploaded images.
- Enhance EditEventDialog to support image uploads and previews, with validation for file size and count.