### PR TITLE
fix: coerce null image_urls to empty list in ForumEventResponse            

### DIFF
--- a/backend/app/models/forum.py
+++ b/backend/app/models/forum.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, BeforeValidator, model_validator
+from pydantic import BaseModel, Field, BeforeValidator, model_validator, field_validator
 from typing import Optional, List, Annotated
 from datetime import datetime
 from bson import ObjectId
@@ -157,6 +157,11 @@ class ForumEventResponse(BaseModel):
     upvote_count: int = 0
     user_upvoted: bool = False
     image_urls: List[str] = Field(default_factory=list)
+
+    @field_validator("image_urls", mode="before")
+    @classmethod
+    def coerce_image_urls(cls, v):
+        return v or []
 
     class Config:
         populate_by_name = True


### PR DESCRIPTION
## Summary                                                                                                                                                                   
  - `ForumEventResponse.image_urls` was declared as `List[str]` but existing documents in the DB return `null` for the field, causing a Pydantic validation error              
  - Added a `field_validator` with `mode="before"` to coerce `None` → `[]` so both old and new documents deserialize correctly                                   
                                                                                                                                                                               
  ## Related                                                                                                                                                                   
  Fixes 2 failing tests in `tests/test_forum_service.py::TestCreateEvent`            