### PR TITLE
Add hover tooltip for For You recommendations

### DIFF
--- a/frontend/src/components/ui/DashboardFilterBar.tsx
+++ b/frontend/src/components/ui/DashboardFilterBar.tsx
@@ -1,6 +1,16 @@
 import { useMemo, useState } from "react";
-import { Button, Flex, Popover, Text, Separator, TextField } from "@radix-ui/themes";
 import {
+  Badge,
+  Button,
+  Flex,
+  HoverCard,
+  Popover,
+  Separator,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
+import {
+  ArrowRightIcon,
   ChevronDownIcon,
   Cross2Icon,
   HeartFilledIcon,
@@ -59,6 +69,7 @@ interface DashboardFilterBarProps {
   onFiltersChange: (filters: DashboardFilters) => void;
   availableTags: TagEntity[];
   hasLocation: boolean;
+  onOpenForYouSettings?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -220,6 +231,73 @@ function OptionGroup({
   );
 }
 
+function ForYouExplanationContent({
+  onOpenForYouSettings,
+}: {
+  onOpenForYouSettings?: () => void;
+}) {
+  return (
+    <div className="for-you-popover-panel">
+      <div className="for-you-popover-hero px-4 py-4">
+        <Flex align="center" gap="3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/85 text-lime-700 shadow-sm dark:bg-black/25 dark:text-lime-300">
+            <HeartFilledIcon className="h-5 w-5" />
+          </div>
+          <div>
+            <Text
+              as="div"
+              size="1"
+              weight="medium"
+              className="uppercase tracking-[0.18em] text-lime-950/65 dark:text-lime-50/70"
+            >
+              For You
+            </Text>
+            <Text as="div" size="4" weight="bold">
+              Why these posts appear
+            </Text>
+          </div>
+        </Flex>
+      </div>
+
+      <div className="space-y-4 px-4 py-4">
+        <Flex gap="2" wrap="wrap">
+          <Badge color="lime" variant="soft">
+            Interests
+          </Badge>
+          <Badge color="amber" variant="soft">
+            Location
+          </Badge>
+          <Badge color="gray" variant="soft">
+            Activity
+          </Badge>
+        </Flex>
+
+        <Text
+          as="div"
+          size="2"
+          className="leading-6 text-[var(--gray-11)]"
+        >
+          We rank these suggestions using the interests on your profile, your
+          city or distance filters, and activity signals like saved or
+          completed exchanges. If we do not have enough signals yet, we may
+          temporarily show nearby posts instead. Update your Interests to make
+          the next recommendations more relevant.
+        </Text>
+
+        <Button
+          size="2"
+          color="lime"
+          className="w-full justify-between"
+          onClick={() => onOpenForYouSettings?.()}
+        >
+          Update interests
+          <ArrowRightIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -229,6 +307,7 @@ export function DashboardFilterBar({
   onFiltersChange,
   availableTags,
   hasLocation,
+  onOpenForYouSettings,
 }: DashboardFilterBarProps) {
   const activeTagCount = filters.selectedTags.length;
 
@@ -269,27 +348,43 @@ export function DashboardFilterBar({
 
   return (
     <div className="filter-bar-scroll flex w-full flex-wrap items-center gap-2 pt-2">
-      <button
-        className={`
-          filter-pill inline-flex items-center gap-1.5 whitespace-nowrap
-          rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 hover:shadow-sm
-          ${
-            filters.forYouOnly
-              ? "border-current font-semibold filter-pill-active text-lime-600"
-              : "border-[var(--gray-6)] text-[var(--gray-11)]"
-          }
-        `}
-        onClick={() => update({ forYouOnly: !filters.forYouOnly })}
-      >
-        <HeartFilledIcon
-          className={`h-3.5 w-3.5 shrink-0 transition-transform duration-200 ${
-            filters.forYouOnly
-              ? "scale-110 text-rose-400"
-              : "text-rose-300"
-          }`}
-        />
-        For you
-      </button>
+      <div className="flex items-center gap-2">
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <button
+              className={`
+                filter-pill inline-flex items-center gap-1.5 whitespace-nowrap
+                rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 hover:shadow-sm
+                ${
+                  filters.forYouOnly
+                    ? "border-current font-semibold filter-pill-active text-lime-600"
+                    : "border-[var(--gray-6)] text-[var(--gray-11)]"
+                }
+              `}
+              onClick={() => update({ forYouOnly: !filters.forYouOnly })}
+            >
+              <HeartFilledIcon
+                className={`h-3.5 w-3.5 shrink-0 transition-transform duration-200 ${
+                  filters.forYouOnly
+                    ? "scale-110 text-rose-400"
+                    : "text-rose-300"
+                }`}
+              />
+              For you
+            </button>
+          </HoverCard.Trigger>
+          <HoverCard.Content
+            side="bottom"
+            align="start"
+            sideOffset={12}
+            className="w-[340px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[22px] p-0"
+          >
+            <ForYouExplanationContent
+              onOpenForYouSettings={onOpenForYouSettings}
+            />
+          </HoverCard.Content>
+        </HoverCard.Root>
+      </div>
 
       {/* Service Type */}
       <FilterPill

--- a/frontend/src/components/ui/__tests__/DashboardFilterBar.test.tsx
+++ b/frontend/src/components/ui/__tests__/DashboardFilterBar.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/constants/turkishCities", () => ({
 function renderBar(
   filters: DashboardFilters = defaultDashboardFilters,
   onFiltersChange = vi.fn(),
+  onOpenForYouSettings = vi.fn(),
 ) {
   return render(
     <DashboardFilterBar
@@ -27,6 +28,7 @@ function renderBar(
         { entityId: "Q2", label: "music", description: "" },
       ]}
       hasLocation={false}
+      onOpenForYouSettings={onOpenForYouSettings}
     />,
   );
 }
@@ -69,6 +71,30 @@ describe("DashboardFilterBar", () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ forYouOnly: true }),
     );
+  });
+
+  it("shows the For You explainer and opens interests from the CTA", async () => {
+    const user = userEvent.setup();
+    const onOpenForYouSettings = vi.fn();
+    renderBar(
+      defaultDashboardFilters,
+      vi.fn(),
+      onOpenForYouSettings,
+    );
+
+    await user.hover(
+      screen.getByRole("button", { name: "For you" }),
+    );
+
+    expect(
+      await screen.findByText("Why these posts appear"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/We rank these suggestions using the interests/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Update interests/i }));
+    expect(onOpenForYouSettings).toHaveBeenCalledTimes(1);
   });
 
   it("shows active pill label when serviceType is set to offer", () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -313,6 +313,38 @@ button {
     background-color: var(--gray-3);
 }
 
+.for-you-popover-panel {
+    border: 1px solid rgba(176, 214, 87, 0.35);
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(249, 250, 241, 0.98));
+    box-shadow:
+        0 22px 50px rgba(151, 181, 76, 0.16),
+        0 10px 22px rgba(251, 191, 36, 0.08);
+}
+
+.dark .for-you-popover-panel {
+    border-color: rgba(176, 214, 87, 0.22);
+    background:
+        linear-gradient(180deg, rgba(26, 31, 20, 0.98), rgba(30, 35, 23, 0.98));
+    box-shadow:
+        0 22px 50px rgba(80, 110, 30, 0.24),
+        0 10px 22px rgba(140, 100, 20, 0.14);
+}
+
+.for-you-popover-hero {
+    background:
+        radial-gradient(circle at top right, rgba(196, 255, 112, 0.34), transparent 34%),
+        radial-gradient(circle at left bottom, rgba(255, 218, 112, 0.2), transparent 42%),
+        linear-gradient(135deg, rgba(235, 247, 194, 0.95), rgba(255, 243, 212, 0.95));
+}
+
+.dark .for-you-popover-hero {
+    background:
+        radial-gradient(circle at top right, rgba(125, 177, 50, 0.26), transparent 34%),
+        radial-gradient(circle at left bottom, rgba(170, 130, 44, 0.16), transparent 42%),
+        linear-gradient(135deg, rgba(39, 50, 24, 0.96), rgba(50, 40, 22, 0.96));
+}
+
 .recommended-listing-card {
     border: 1px solid rgba(176, 214, 87, 0.5) !important;
     background:

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -105,6 +105,9 @@ export function Dashboard() {
         ? false
         : undefined;
   const activeCity = dashFilters.city;
+  const openInterestsEditor = useCallback(() => {
+    navigate("/profile?tab=profile&interests=true");
+  }, [navigate]);
 
   useEffect(() => {
     if (selectedCity === activeCity) return;
@@ -539,6 +542,7 @@ export function Dashboard() {
           onFiltersChange={handleDashFiltersChange}
           availableTags={availableTags}
           hasLocation={userPosition !== null}
+          onOpenForYouSettings={openInterestsEditor}
         />
         {showProfilePrompt && (
           <Callout.Root size="1" color="lime" variant="soft">
@@ -561,9 +565,7 @@ export function Dashboard() {
                   size="1"
                   color="lime"
                   variant="soft"
-                  onClick={() =>
-                    navigate("/profile?tab=profile&interests=true")
-                  }
+                  onClick={openInterestsEditor}
                 >
                   Go to Interests
                 </Button>


### PR DESCRIPTION
Adds a hover tooltip to the "For you" filter on the dashboard so users can understand why recommendations appear without clicking a separate info icon. The tooltip explains that suggestions are based on profile interests, location/distance filters, and user activity, and includes a shortcut to update interests.

closes #328 