### PR TITLE
Add PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+Closes {LINK TO GH ISSUE}
+
+## Description
+
+A clear and concise description of the PR.
+
+Use this section for review hints, explanations or discussion points/todos.
+
+- Summary of changes
+- Reasoning
+- Additional context
+
+How to contribute: https://kelpui.com/docs/getting-started/contributing/
+
+
+## Screenshots
+
+Screenshots or a screen recording of the visual changes associated with this PR.
+
+(Feel free to delete this section for non-visual changes.)
+
+
+## Test Plan
+
+How to test this feature/bug fix?


### PR DESCRIPTION
Closes: #285 

## Description

This PR adds a standard GitHub pull request template to the repository to help contributors provide consistent context (summary, reasoning, screenshots, and test plan) for reviewers.

- **Summary of changes**
  - Add `.github/pull_request_template.md` with sections for Description, Screenshots, and Test Plan
  - Include contribution docs link in the template

- **Reasoning**
  - Improve review quality and consistency by prompting authors for the key info reviewers need

- **Additional context**
  - None

## Screenshots

N/A (non-visual change)

## Test Plan

- Confirm the PR template appears automatically when opening a new PR in GitHub
- Verify the sections render correctly (Description / Screenshots / Test Plan)