### PR TITLE
Add GitHub Actions workflow for building and uploading mobile application

### DIFF
--- a/.github/workflows/mobile-apk-artifact.yml
+++ b/.github/workflows/mobile-apk-artifact.yml
@@ -1,0 +1,68 @@
+name: Mobile APK (Artifact)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "app/**"
+      - ".github/workflows/mobile-apk-artifact.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build release APK
+        working-directory: app
+        run: |
+          chmod +x gradlew
+          ./gradlew :app:assembleRelease
+
+      - name: Find APK
+        id: apk
+        working-directory: app
+        shell: bash
+        run: |
+          shopt -s nullglob
+          apks=(app/build/outputs/apk/release/*.apk)
+          if [ ${#apks[@]} -eq 0 ]; then
+            echo "No APKs found in app/build/outputs/apk/release/"
+            ls -R app/build/outputs/apk || true
+            exit 1
+          fi
+          if [ ${#apks[@]} -gt 1 ]; then
+            echo "Multiple APKs found; uploading them all."
+          fi
+          {
+            echo "paths<<'EOF'"
+            for apk in "${apks[@]}"; do
+              echo "app/$apk"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-apk
+          path: |
+            ${{ steps.apk.outputs.paths }}
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Closes #347

## Description

This pull request adds a GitHub Actions workflow that builds the Android mobile app from the `app/` directory and uploads the resulting APK as a **GitHub Actions Artifact** on every push to `main` (including merges from PRs). It also supports manual runs via `workflow_dispatch` so the pipeline can be exercised without waiting for a merge.

The workflow builds `:app:assembleRelease`. The project’s Gradle configuration already maps the `release` build type to the debug signing configuration, so this does not require keystore secrets in CI.

To avoid unnecessary CI runs, the workflow is scoped with `paths` filters so it only runs when files under `app/` change (or when the workflow file itself changes).

## Screenshots

N/A (CI-only change)

## Test Plan

- Merge this PR to `main` (or ensure the workflow file exists on `main`).
- Go to **GitHub → Actions → “Mobile APK (Artifact)” → Run workflow** (manual dispatch).
- Confirm the workflow completes successfully.
- Open the workflow run page and verify the **`mobile-apk`** artifact is present and downloadable.
- (Optional) Push a small change under `app/` to `main` and confirm the workflow triggers automatically.