### PR TITLE
Enhance community banners and member visibility

### DIFF
--- a/backend/app/api/community.py
+++ b/backend/app/api/community.py
@@ -148,10 +148,12 @@ async def leave_community(
 @router.get("/{community_id}/members", response_model=MembershipListResponse)
 async def get_members(
     community_id: str,
+    current_user: Optional[UserResponse] = Depends(get_optional_current_user),
     db=Depends(get_database),
 ):
     svc = _svc(db)
-    members, total = await svc.get_members(community_id)
+    user_id = str(current_user.id) if current_user else None
+    members, total = await svc.get_members(community_id, user_id)
     return MembershipListResponse(members=members, total=total)
 
 

--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -80,6 +80,18 @@ async def upload_service_image(
     return {"url": url}
 
 
+@router.post("/community-image")
+async def upload_community_image(
+    file: UploadFile = File(...),
+    current_user: UserResponse = Depends(get_current_user),
+):
+    """Upload an image for a community avatar or cover. Returns the URL."""
+    ext = _validate_image(file)
+    filename = f"{uuid.uuid4().hex}{ext}"
+    url = _save_upload(file, "communities", filename)
+    return {"url": url}
+
+
 @router.post("/rating-image")
 async def upload_rating_image(
     file: UploadFile = File(...),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ async def lifespan(app: FastAPI):
     await connect_to_mongo()
     # Ensure upload directories exist
     upload_dir = settings.upload_dir
-    for sub in ("profile", "services", "comments"):
+    for sub in ("profile", "services", "communities", "ratings", "comments", "forum-events", "discussions"):
         path = os.path.join(upload_dir, sub)
         os.makedirs(path, exist_ok=True)
     logger.info("Application startup complete")
@@ -67,7 +67,7 @@ app.include_router(community.router)
 # Ensure upload directory exists before mounting (StaticFiles requires it at init)
 upload_dir = settings.upload_dir
 os.makedirs(upload_dir, exist_ok=True)
-for sub in ("profile", "services", "comments"):
+for sub in ("profile", "services", "communities", "ratings", "comments", "forum-events", "discussions"):
     os.makedirs(os.path.join(upload_dir, sub), exist_ok=True)
 
 # Mount static files for uploaded images (must be after routes to avoid shadowing)

--- a/backend/app/models/community.py
+++ b/backend/app/models/community.py
@@ -118,6 +118,7 @@ class MembershipResponse(BaseModel):
     status: MemberStatus
     joined_at: datetime
     user: Optional[dict] = None
+    mutual_community_count: Optional[int] = None
 
     class Config:
         populate_by_name = True

--- a/backend/app/services/community_service.py
+++ b/backend/app/services/community_service.py
@@ -276,13 +276,32 @@ class CommunityService:
         )
         return await self.get_community_by_id(community_id, user_id)
 
-    async def get_members(self, community_id: str) -> Tuple[List[dict], int]:
+    async def get_members(
+        self,
+        community_id: str,
+        current_user_id: Optional[str] = None,
+    ) -> Tuple[List[dict], int]:
         query = {"community_id": ObjectId(community_id), "status": MemberStatus.ACTIVE}
         total = await self.memberships.count_documents(query)
         cursor = self.memberships.find(query).sort("joined_at", 1)
         docs = await cursor.to_list(length=500)
+
+        current_user_community_ids = None
+        current_user_community_object_ids = []
+        if current_user_id:
+            current_user_memberships = await self.memberships.find({
+                "user_id": ObjectId(current_user_id),
+                "status": MemberStatus.ACTIVE,
+            }).to_list(length=500)
+            current_user_community_ids = {
+                str(m["community_id"]) for m in current_user_memberships
+            }
+            current_user_community_object_ids = [
+                ObjectId(cid) for cid in current_user_community_ids
+            ]
+
         for doc in docs:
-            user = await self.users.find_one({"_id": doc["user_id"]})
+            user = await self.users.find_one({"_id": ObjectId(str(doc["user_id"]))})
             if user:
                 doc["user"] = {
                     "id": str(user["_id"]),
@@ -290,6 +309,15 @@ class CommunityService:
                     "full_name": user.get("full_name"),
                     "profile_picture": user.get("profile_picture"),
                 }
+            if current_user_community_ids is not None:
+                if str(doc["user_id"]) == current_user_id:
+                    doc["mutual_community_count"] = len(current_user_community_ids)
+                else:
+                    doc["mutual_community_count"] = await self.memberships.count_documents({
+                        "user_id": ObjectId(str(doc["user_id"])),
+                        "status": MemberStatus.ACTIVE,
+                        "community_id": {"$in": current_user_community_object_ids},
+                    })
         return docs, total
 
     async def update_member_role(self, community_id: str, target_user_id: str, role: MemberRole, requester_id: str):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -195,6 +195,9 @@ class AsyncMockDatabase:
     def __init__(self, sync_db):
         self._sync_db = sync_db
         self.client = sync_db.client
+
+    def __getitem__(self, name):
+        return AsyncMockCollection(self._sync_db[name])
     
     def __getattr__(self, name):
         if name.startswith('_'):

--- a/backend/tests/test_community_service.py
+++ b/backend/tests/test_community_service.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+
+from app.models.community import CommunityCreate
+from app.services.community_service import CommunityService
+
+
+def make_user_doc(user_id, username):
+    return {
+        "_id": ObjectId(user_id),
+        "username": username,
+        "full_name": f"{username} full",
+        "email": f"{username}@example.com",
+        "password_hash": "hash",
+        "is_active": True,
+        "is_verified": True,
+        "role": "user",
+        "timebank_balance": 5.0,
+        "profile_picture": None,
+        "profile_visible": True,
+        "show_email": False,
+        "show_location": True,
+        "email_notifications": True,
+        "service_matches_notifications": True,
+        "messages_notifications": True,
+        "interests": [],
+        "social_links": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+
+
+async def create_community(svc, name, user_id):
+    return await svc.create_community(
+        CommunityCreate(name=name, description=f"{name} description"),
+        user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_members_includes_mutual_community_count(mock_db):
+    viewer_id = str(ObjectId())
+    member_id = str(ObjectId())
+    await mock_db.users.insert_one(make_user_doc(viewer_id, "viewer"))
+    await mock_db.users.insert_one(make_user_doc(member_id, "member"))
+
+    svc = CommunityService(mock_db)
+    listed = await create_community(svc, "Running Club", viewer_id)
+    await svc.join_community(str(listed["_id"]), member_id)
+
+    second_common = await create_community(svc, "Book Club", member_id)
+    await svc.join_community(str(second_common["_id"]), viewer_id)
+
+    await create_community(svc, "Viewer Only", viewer_id)
+    await create_community(svc, "Member Only", member_id)
+
+    members, total = await svc.get_members(str(listed["_id"]), viewer_id)
+
+    assert total == 2
+    listed_member = next(m for m in members if str(m["user_id"]) == member_id)
+    viewer_member = next(m for m in members if str(m["user_id"]) == viewer_id)
+    assert listed_member["mutual_community_count"] == 2
+    assert viewer_member["mutual_community_count"] == 3
+    assert listed_member["user"]["username"] == "member"

--- a/frontend/src/pages/CommunityDetail.tsx
+++ b/frontend/src/pages/CommunityDetail.tsx
@@ -10,9 +10,9 @@ import {
   TrashIcon, ChevronUpIcon,
 } from "@radix-ui/react-icons";
 import { MessageCircleIcon, UsersIcon, PinIcon } from "lucide-react";
-import { communityApi, getImageUrl } from "@/services/api";
+import { communityApi, getImageUrl, uploadApi } from "@/services/api";
 import { useUser } from "@/App";
-import { Community, CommunityPost, TagEntity, ForumEvent, ForumDiscussion } from "@/types";
+import { Community, CommunityMember, CommunityPost, TagEntity, ForumEvent, ForumDiscussion } from "@/types";
 import { ClickableTag } from "@/components/ui/ClickableTag";
 import { UpvoteButton } from "@/components/ui/UpvoteButton";
 import { MarkdownEditor } from "@/components/forms/MarkdownEditor";
@@ -49,6 +49,10 @@ export function CommunityDetail() {
   const [showEditCommunity, setShowEditCommunity] = useState(false);
   const [showDeleteCommunity, setShowDeleteCommunity] = useState(false);
   const [membershipLoading, setMembershipLoading] = useState(false);
+  const [showMembers, setShowMembers] = useState(false);
+  const [members, setMembers] = useState<CommunityMember[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [membersError, setMembersError] = useState("");
   const [communityEvents, setCommunityEvents] = useState<ForumEvent[]>([]);
   const [communityDiscussions, setCommunityDiscussions] = useState<ForumDiscussion[]>([]);
 
@@ -124,6 +128,26 @@ export function CommunityDetail() {
     navigate("/forum?tab=communities");
   };
 
+  const loadMembers = async () => {
+    if (!id) return;
+    setMembersLoading(true);
+    setMembersError("");
+    try {
+      const res = await communityApi.getMembers(id);
+      setMembers(res.data.members);
+    } catch (e: any) {
+      setMembers([]);
+      setMembersError(e?.response?.data?.detail || "Failed to load members");
+    } finally {
+      setMembersLoading(false);
+    }
+  };
+
+  const openMembersDialog = () => {
+    setShowMembers(true);
+    void loadMembers();
+  };
+
   if (loading) {
     return <Card className="p-8 text-center"><Text color="gray">Loading...</Text></Card>;
   }
@@ -139,15 +163,19 @@ export function CommunityDetail() {
       </Button>
 
       {/* Community header */}
-      {community.cover_image_url && (
-        <div className="w-full h-40 rounded-xl overflow-hidden mb-4">
+      <div className="w-full h-40 rounded-xl overflow-hidden mb-4 bg-[var(--grass-3)]">
+        {community.cover_image_url ? (
           <img
             src={getImageUrl(community.cover_image_url) ?? community.cover_image_url}
-            alt="Cover"
+            alt={`${community.name} banner`}
             className="w-full h-full object-cover"
           />
-        </div>
-      )}
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <UsersIcon className="h-12 w-12 text-[var(--grass-9)]" />
+          </div>
+        )}
+      </div>
 
       <Card className="p-6 mb-6">
         <Flex gap="4" align="start">
@@ -169,9 +197,9 @@ export function CommunityDetail() {
                 </Flex>
               </div>
               <Flex gap="2" align="center">
-                <Badge size="2" variant="soft" color="gray">
+                <Button size="2" variant="soft" color="gray" onClick={openMembersDialog}>
                   <UsersIcon className="w-3 h-3 mr-1" /> {community.member_count} members
-                </Badge>
+                </Button>
                 <Badge size="2" variant="soft" color="gray">
                   <MessageCircleIcon className="w-3 h-3 mr-1" /> {community.post_count} posts
                 </Badge>
@@ -345,6 +373,18 @@ export function CommunityDetail() {
       )}
 
       {/* Dialogs */}
+      <CommunityMembersDialog
+        open={showMembers}
+        onOpenChange={setShowMembers}
+        members={members}
+        loading={membersLoading}
+        error={membersError}
+        currentUserId={currentUserId}
+        onOpenUser={(userId) => {
+          setShowMembers(false);
+          navigate(`/user/${userId}`);
+        }}
+      />
       <NewPostDialog
         open={showNewPost}
         onOpenChange={setShowNewPost}
@@ -368,6 +408,102 @@ export function CommunityDetail() {
         onConfirm={handleDeleteCommunity}
       />
     </div>
+  );
+}
+
+// ─── Members Dialog ───────────────────────────────────────────
+
+function CommunityMembersDialog({
+  open,
+  onOpenChange,
+  members,
+  loading,
+  error,
+  currentUserId,
+  onOpenUser,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  members: CommunityMember[];
+  loading: boolean;
+  error: string;
+  currentUserId: string | null;
+  onOpenUser: (userId: string) => void;
+}) {
+  const mutualText = (member: CommunityMember) => {
+    const isCurrentUser = member.user_id === currentUserId || member.user?.id === currentUserId;
+    if (isCurrentUser) return "You";
+    const count = member.mutual_community_count ?? 0;
+    return `${count} common ${count === 1 ? "community" : "communities"}`;
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content className="max-w-lg" aria-describedby={undefined}>
+        <Dialog.Title>Community Members</Dialog.Title>
+        <div className="mt-4 space-y-3">
+          {loading ? (
+            <Card className="p-6 text-center">
+              <Text color="gray">Loading members...</Text>
+            </Card>
+          ) : error ? (
+            <Card className="p-6 text-center">
+              <Text color="red">{error}</Text>
+            </Card>
+          ) : members.length === 0 ? (
+            <Card className="p-6 text-center">
+              <Text color="gray">No members found.</Text>
+            </Card>
+          ) : (
+            members.map((member) => {
+              const userId = member.user?.id || member.user_id;
+              const displayName =
+                member.user?.full_name || member.user?.username || "Unknown member";
+              return (
+                <Card
+                  key={member._id}
+                  className={userId ? "hover-card cursor-pointer" : ""}
+                  onClick={() => userId && onOpenUser(userId)}
+                >
+                  <Flex gap="3" align="center" justify="between">
+                    <Flex gap="3" align="center" className="min-w-0">
+                      <Avatar
+                        size="3"
+                        src={getImageUrl(member.user?.profile_picture)}
+                        fallback={displayName[0] || "?"}
+                        radius="full"
+                      />
+                      <div className="min-w-0">
+                        <Text size="2" weight="bold" className="block truncate">
+                          {displayName}
+                        </Text>
+                        <Flex gap="2" align="center" wrap="wrap">
+                          {member.user?.username && (
+                            <Text size="1" color="gray">
+                              @{member.user.username}
+                            </Text>
+                          )}
+                          <Text size="1" color="gray">
+                            {mutualText(member)}
+                          </Text>
+                        </Flex>
+                      </div>
+                    </Flex>
+                    <Badge size="1" variant="soft" color={member.role === "founder" ? "violet" : "gray"}>
+                      {member.role === "founder"
+                        ? "Founder"
+                        : member.role === "moderator"
+                          ? "Mod"
+                          : "Member"}
+                    </Badge>
+                  </Flex>
+                </Card>
+              );
+            })
+          )}
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
   );
 }
 
@@ -464,6 +600,10 @@ function EditCommunityDialog({
   const [tags, setTags] = useState<TagEntity[]>(community.tags ?? []);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(null);
+  const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -471,15 +611,64 @@ function EditCommunityDialog({
       setDescription(community.description);
       setRules(community.rules ?? []);
       setTags(community.tags ?? []);
+      setAvatarFile(null);
+      setCoverFile(null);
+      setAvatarPreviewUrl(null);
+      setCoverPreviewUrl(null);
       setError("");
     }
   }, [open, community]);
+
+  const resetImageSelections = () => {
+    if (avatarPreviewUrl) URL.revokeObjectURL(avatarPreviewUrl);
+    if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+    setAvatarFile(null);
+    setCoverFile(null);
+    setAvatarPreviewUrl(null);
+    setCoverPreviewUrl(null);
+  };
+
+  const handleCommunityImageChange = (
+    file: File | undefined,
+    type: "avatar" | "cover",
+  ) => {
+    if (!file) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setError("Image must be under 5 MB");
+      return;
+    }
+    const previewUrl = URL.createObjectURL(file);
+    setError("");
+    if (type === "avatar") {
+      if (avatarPreviewUrl) URL.revokeObjectURL(avatarPreviewUrl);
+      setAvatarFile(file);
+      setAvatarPreviewUrl(previewUrl);
+    } else {
+      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+      setCoverFile(file);
+      setCoverPreviewUrl(previewUrl);
+    }
+  };
 
   const handleSubmit = async () => {
     if (!name.trim() || !description.trim()) { setError("Name and description are required"); return; }
     setSubmitting(true);
     try {
-      const res = await communityApi.updateCommunity(community._id, { name, description, rules, tags });
+      const avatarUrl = avatarFile
+        ? (await uploadApi.uploadCommunityImage(avatarFile)).data.url
+        : community.avatar_url;
+      const coverUrl = coverFile
+        ? (await uploadApi.uploadCommunityImage(coverFile)).data.url
+        : community.cover_image_url;
+      const res = await communityApi.updateCommunity(community._id, {
+        name,
+        description,
+        rules,
+        tags,
+        avatar_url: avatarUrl,
+        cover_image_url: coverUrl,
+      });
+      resetImageSelections();
       onUpdated(res.data);
       onOpenChange(false);
     } catch (e: any) {
@@ -490,7 +679,7 @@ function EditCommunityDialog({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={(o) => { if (!o) resetImageSelections(); onOpenChange(o); }}>
       <Dialog.Content className="max-w-2xl" aria-describedby={undefined}>
         <Dialog.Title>Edit Community</Dialog.Title>
         <Form.Root onSubmit={(e) => { e.preventDefault(); void handleSubmit(); }} className="space-y-4 mt-4">
@@ -504,6 +693,56 @@ function EditCommunityDialog({
             <Form.Label className="text-sm font-medium">Description *</Form.Label>
             <MarkdownEditor value={description} onChange={(v) => setDescription(v)} rows={5} />
           </Form.Field>
+          <div className="grid gap-3 md:grid-cols-2">
+            <Box className="space-y-2">
+              <Text size="2" weight="medium" className="block">Community photo</Text>
+              <label className="block cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="sr-only"
+                  disabled={submitting}
+                  onChange={(e) => {
+                    handleCommunityImageChange(e.target.files?.[0], "avatar");
+                    e.target.value = "";
+                  }}
+                />
+                <Avatar
+                  size="6"
+                  src={avatarPreviewUrl || getImageUrl(community.avatar_url)}
+                  fallback={name[0] || community.name[0]}
+                  radius="full"
+                  className="ring-1 ring-[var(--gray-6)]"
+                />
+              </label>
+            </Box>
+            <Box className="space-y-2">
+              <Text size="2" weight="medium" className="block">Banner image</Text>
+              <label className="block cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="sr-only"
+                  disabled={submitting}
+                  onChange={(e) => {
+                    handleCommunityImageChange(e.target.files?.[0], "cover");
+                    e.target.value = "";
+                  }}
+                />
+                {coverPreviewUrl || community.cover_image_url ? (
+                  <img
+                    src={coverPreviewUrl || getImageUrl(community.cover_image_url) || community.cover_image_url}
+                    alt="Community banner preview"
+                    className="h-28 w-full rounded-lg object-cover ring-1 ring-[var(--gray-6)]"
+                  />
+                ) : (
+                  <span className="flex h-28 w-full items-center justify-center rounded-lg border border-dashed border-[var(--gray-7)] text-sm font-medium text-[var(--gray-11)]">
+                    Choose banner
+                  </span>
+                )}
+              </label>
+            </Box>
+          </div>
           <Form.Field name="tags" className="space-y-1">
             <Form.Label className="text-sm font-medium">Tags</Form.Label>
             <TagAutocomplete tags={tags} onTagAdd={(t) => setTags([...tags, t])} onTagRemove={(t) => setTags(tags.filter((x) => x.label !== t.label))} />
@@ -527,7 +766,7 @@ function EditCommunityDialog({
           </div>
           {error && <Text size="2" color="red">{error}</Text>}
           <Flex justify="end" gap="3">
-            <Button type="button" variant="soft" color="gray" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="button" variant="soft" color="gray" onClick={() => { resetImageSelections(); onOpenChange(false); }}>Cancel</Button>
             <Form.Submit asChild>
               <Button type="submit" disabled={submitting}>{submitting ? "Saving..." : "Save Changes"}</Button>
             </Form.Submit>

--- a/frontend/src/pages/Forum.tsx
+++ b/frontend/src/pages/Forum.tsx
@@ -579,11 +579,11 @@ export function Forum() {
                   size="3"
                   onClick={() => navigate(`/forum/communities/${c._id}`)}
                 >
-                  {c.avatar_url && (
-                    <Inset clip="padding-box" side="top" pb="current">
+                  <Inset clip="padding-box" side="top" pb="current">
+                    {c.cover_image_url ? (
                       <img
-                        src={getImageUrl(c.avatar_url) ?? c.avatar_url}
-                        alt={c.name}
+                        src={getImageUrl(c.cover_image_url) ?? c.cover_image_url}
+                        alt={`${c.name} banner`}
                         loading="lazy"
                         style={{
                           display: "block",
@@ -593,17 +593,33 @@ export function Forum() {
                           backgroundColor: "var(--gray-5)",
                         }}
                       />
-                    </Inset>
-                  )}
+                    ) : (
+                      <div className="flex h-40 w-full items-center justify-center bg-[var(--grass-3)]">
+                        <UsersIcon className="h-10 w-10 text-[var(--grass-9)]" />
+                      </div>
+                    )}
+                  </Inset>
+                  <Flex justify="between" align="end" gap="3" className="-mt-8 mb-3">
+                    <Avatar
+                      size="5"
+                      src={getImageUrl(c.avatar_url)}
+                      fallback={c.name[0]}
+                      radius="full"
+                      className="ring-4 ring-[var(--color-background)]"
+                    />
+                    <Flex gap="2" align="center" className="mb-1">
+                      <Badge size="1" variant="soft" color="gray">
+                        <UsersIcon className="w-3 h-3" />
+                        {c.member_count}
+                      </Badge>
+                      <Badge size="1" variant="soft" color="gray">
+                        <MessageCircleIcon className="w-3 h-3" />
+                        {c.post_count}
+                      </Badge>
+                    </Flex>
+                  </Flex>
                   <Flex justify="between" align="start" wrap="wrap" gap="2">
                     <Flex align="center" gap="2">
-                      {!c.avatar_url && (
-                        <Avatar
-                          size="2"
-                          fallback={c.name[0]}
-                          radius="full"
-                        />
-                      )}
                       <Text size="3" weight="bold" className="line-clamp-1">
                         {c.name}
                       </Text>
@@ -614,18 +630,8 @@ export function Forum() {
                             : c.user_membership === "moderator"
                               ? "Mod"
                               : "Member"}
-                        </Badge>
+                          </Badge>
                       )}
-                    </Flex>
-                    <Flex gap="2" align="center">
-                      <Badge size="1" variant="soft" color="gray">
-                        <UsersIcon className="w-3 h-3" />
-                        {c.member_count}
-                      </Badge>
-                      <Badge size="1" variant="soft" color="gray">
-                        <MessageCircleIcon className="w-3 h-3" />
-                        {c.post_count}
-                      </Badge>
                     </Flex>
                   </Flex>
                   <Text size="2" color="gray" className="line-clamp-2">
@@ -870,7 +876,10 @@ function NewDiscussionDialog({
               type="button"
               variant="soft"
               color="gray"
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+              }}
             >
               Cancel
             </Button>
@@ -1189,7 +1198,10 @@ function NewEventDialog({
               type="button"
               variant="soft"
               color="gray"
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+              }}
             >
               Cancel
             </Button>
@@ -1224,6 +1236,10 @@ function NewCommunityDialog({
   const [tags, setTags] = useState<TagEntity[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(null);
+  const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(null);
 
   const reset = () => {
     setName("");
@@ -1232,6 +1248,12 @@ function NewCommunityDialog({
     setNewRule("");
     setTags([]);
     setError("");
+    if (avatarPreviewUrl) URL.revokeObjectURL(avatarPreviewUrl);
+    if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+    setAvatarFile(null);
+    setCoverFile(null);
+    setAvatarPreviewUrl(null);
+    setCoverPreviewUrl(null);
   };
 
   const handleAddRule = () => {
@@ -1242,18 +1264,50 @@ function NewCommunityDialog({
     }
   };
 
+  const handleCommunityImageChange = (
+    file: File | undefined,
+    type: "avatar" | "cover",
+  ) => {
+    if (!file) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setError("Image must be under 5 MB");
+      return;
+    }
+    const previewUrl = URL.createObjectURL(file);
+    setError("");
+    if (type === "avatar") {
+      if (avatarPreviewUrl) URL.revokeObjectURL(avatarPreviewUrl);
+      setAvatarFile(file);
+      setAvatarPreviewUrl(previewUrl);
+    } else {
+      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+      setCoverFile(file);
+      setCoverPreviewUrl(previewUrl);
+    }
+  };
+
   const handleSubmit = async () => {
     if (!name.trim() || !description.trim()) {
       setError("Name and description are required");
       return;
     }
+    if (!avatarFile || !coverFile) {
+      setError("Community photo and banner image are required");
+      return;
+    }
     setSubmitting(true);
     try {
+      const [avatarRes, coverRes] = await Promise.all([
+        uploadApi.uploadCommunityImage(avatarFile),
+        uploadApi.uploadCommunityImage(coverFile),
+      ]);
       const res = await communityApi.createCommunity({
         name,
         description,
         rules,
         tags,
+        avatar_url: avatarRes.data.url,
+        cover_image_url: coverRes.data.url,
       });
       reset();
       onOpenChange(false);
@@ -1305,6 +1359,64 @@ function NewCommunityDialog({
               rows={5}
             />
           </Form.Field>
+          <div className="grid gap-3 md:grid-cols-2">
+            <Box className="space-y-2">
+              <Text size="2" weight="medium" className="block">
+                Community photo *
+              </Text>
+              <label className="block cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="sr-only"
+                  disabled={submitting}
+                  onChange={(e) => {
+                    handleCommunityImageChange(e.target.files?.[0], "avatar");
+                    e.target.value = "";
+                  }}
+                />
+                {avatarPreviewUrl ? (
+                  <img
+                    src={avatarPreviewUrl}
+                    alt="Community photo preview"
+                    className="h-32 w-32 rounded-full object-cover ring-1 ring-[var(--gray-6)]"
+                  />
+                ) : (
+                  <span className="flex h-32 w-32 items-center justify-center rounded-full border border-dashed border-[var(--gray-7)] text-sm font-medium text-[var(--gray-11)]">
+                    Choose photo
+                  </span>
+                )}
+              </label>
+            </Box>
+            <Box className="space-y-2">
+              <Text size="2" weight="medium" className="block">
+                Banner image *
+              </Text>
+              <label className="block cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="sr-only"
+                  disabled={submitting}
+                  onChange={(e) => {
+                    handleCommunityImageChange(e.target.files?.[0], "cover");
+                    e.target.value = "";
+                  }}
+                />
+                {coverPreviewUrl ? (
+                  <img
+                    src={coverPreviewUrl}
+                    alt="Community banner preview"
+                    className="h-32 w-full rounded-lg object-cover ring-1 ring-[var(--gray-6)]"
+                  />
+                ) : (
+                  <span className="flex h-32 w-full items-center justify-center rounded-lg border border-dashed border-[var(--gray-7)] text-sm font-medium text-[var(--gray-11)]">
+                    Choose banner
+                  </span>
+                )}
+              </label>
+            </Box>
+          </div>
           <Form.Field name="tags" className="space-y-1">
             <Form.Label className="text-sm font-medium">Tags</Form.Label>
             <TagAutocomplete
@@ -1370,7 +1482,10 @@ function NewCommunityDialog({
               type="button"
               variant="soft"
               color="gray"
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+              }}
             >
               Cancel
             </Button>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -96,6 +96,16 @@ export const uploadApi = {
       }],
     });
   },
+  uploadCommunityImage: (file: File): Promise<AxiosResponse<{ url: string }>> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    return api.post('/upload/community-image', formData, {
+      transformRequest: [(data: unknown, headers?: Record<string, string>) => {
+        if (headers) delete headers['Content-Type'];
+        return data;
+      }],
+    });
+  },
   uploadRatingImage: (file: File): Promise<AxiosResponse<{ url: string }>> => {
     const formData = new FormData();
     formData.append('file', file);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -780,6 +780,7 @@ export interface CommunityMember {
   status: MemberStatus;
   joined_at: string;
   user?: ForumAuthor;
+  mutual_community_count?: number | null;
 }
 
 export interface CommunityMemberListResponse {


### PR DESCRIPTION
Closes #357 
Closes #354 
Closes #340

## Description

This PR improves the community experience by adding distinct community avatar and banner image support, and by making community membership more transparent.

- Added separate community photo and banner image fields to the community create/edit flows.
- Added a community image upload endpoint for storing avatar/banner assets.
- Updated community cards to show `cover_image_url` as the banner and `avatar_url` as the round community photo.
- Updated community detail pages to show the banner consistently.
- Made the member count clickable on community detail pages.
- Added a members dialog that lists community members and shows how many communities each member has in common with the current user.
- Extended the members API response with `mutual_community_count`.

Reasoning:
- Communities need both a profile image and a wider banner image for clearer identity and better visual hierarchy.
- Member discovery should feel more social, similar to seeing mutual connections on social platforms.

Additional context:
- Existing `avatar_url` and `cover_image_url` fields were already present in the community model, but the web create/edit UI did not fully support them.
- The mutual community count is calculated server-side using active community memberships.


## Screenshots

<img width="516" height="230" alt="Ekran Resmi 2026-05-02 ÖS 7 38 37" src="https://github.com/user-attachments/assets/06478c5d-e4a2-49f7-92dd-8ea41e0cfa27" />


## Test Plan

- [ ] Open app and navigate to Forum > Communities.
- [ ] Create a community with name, description, rules/tags, community photo, and banner image.
- [ ] Verify the new community appears in the community list with the banner image and round avatar displayed correctly.
- [ ] Open the community detail page and verify the banner is shown at the top.
- [ ] Edit the community and verify changing the community photo/banner persists correctly.
- [ ] Click the member count on the community detail page.
- [ ] Verify the members dialog opens and lists members with their mutual community counts.
- [ ] Regression check: existing community browsing, join/leave, and post display still work.
