### PR TITLE
feat: settings page, activity tab, and mock data seeding                              

### DIFF
--- a/backend/scripts/seed_mock_data.py
+++ b/backend/scripts/seed_mock_data.py
@@ -13,31 +13,86 @@ from datetime import datetime, timedelta, timezone
 SEED_MARKER = True
 
 IMAGES = {
-    "workshop":     "https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?w=800&auto=format&fit=crop",
-    "laptop":       "https://images.unsplash.com/photo-1496181133206-80ce9b88a853?w=800&auto=format&fit=crop",
-    "conversation": "https://images.unsplash.com/photo-1543269865-cbf427effbad?w=800&auto=format&fit=crop",
-    "gardening":    "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&auto=format&fit=crop",
-    "coding":       "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=800&auto=format&fit=crop",
-    "furniture":    "https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&auto=format&fit=crop",
-    "photography":  "https://images.unsplash.com/photo-1516035069371-29a1b244cc32?w=800&auto=format&fit=crop",
-    "books":        "https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&auto=format&fit=crop",
-    "garden":       "https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?w=800&auto=format&fit=crop",
-    "plants":       "https://images.unsplash.com/photo-1463936575829-25148e1db1b8?w=800&auto=format&fit=crop",
-    "breakfast":    "https://images.unsplash.com/photo-1533089860892-a7c6f0a88666?w=800&auto=format&fit=crop",
-    "park":         "https://images.unsplash.com/photo-1533044309907-0fa3413da946?w=800&auto=format&fit=crop",
-    "repair_cover": "https://images.unsplash.com/photo-1581092160607-ee22621dd758?w=1200&auto=format&fit=crop",
+    # Service images
+    "laptop":         "https://images.unsplash.com/photo-1496181133206-80ce9b88a853?w=800&auto=format&fit=crop",
+    "laptop2":        "https://images.unsplash.com/photo-1588872657578-7efd1f1555ed?w=800&auto=format&fit=crop",
+    "conversation":   "https://images.unsplash.com/photo-1543269865-cbf427effbad?w=800&auto=format&fit=crop",
+    "conversation2":  "https://images.unsplash.com/photo-1529156069898-49953e39b3ac?w=800&auto=format&fit=crop",
+    "gardening":      "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&auto=format&fit=crop",
+    "gardening2":     "https://images.unsplash.com/photo-1591857177580-dc82b9ac4e1e?w=800&auto=format&fit=crop",
+    "coding":         "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=800&auto=format&fit=crop",
+    "coding2":        "https://images.unsplash.com/photo-1461749280684-dccba630e2f6?w=800&auto=format&fit=crop",
+    "furniture":      "https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&auto=format&fit=crop",
+    "photography":    "https://images.unsplash.com/photo-1516035069371-29a1b244cc32?w=800&auto=format&fit=crop",
+    "photography2":   "https://images.unsplash.com/photo-1452780212658-9a4d0f80fe43?w=800&auto=format&fit=crop",
+    "bread":          "https://images.unsplash.com/photo-1549931319-a545dcf3bc73?w=800&auto=format&fit=crop",
+    "bread2":         "https://images.unsplash.com/photo-1565181552583-7dfa4e000be4?w=800&auto=format&fit=crop",
+    "bike":           "https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=800&auto=format&fit=crop",
+    "bike2":          "https://images.unsplash.com/photo-1571068316344-75bc76f77890?w=800&auto=format&fit=crop",
+    "yoga":           "https://images.unsplash.com/photo-1506126613408-eca07ce68773?w=800&auto=format&fit=crop",
+    "cooking":        "https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=800&auto=format&fit=crop",
+    "cooking2":       "https://images.unsplash.com/photo-1528712306091-ed0763094c98?w=800&auto=format&fit=crop",
+    "fermentation":   "https://images.unsplash.com/photo-1608686207856-001b95cf60ca?w=800&auto=format&fit=crop",
+    "fermentation2":  "https://images.unsplash.com/photo-1582266255765-fa5cf1a1d501?w=800&auto=format&fit=crop",
+    "calligraphy":    "https://images.unsplash.com/photo-1585011664466-b7bbe92f34ef?w=800&auto=format&fit=crop",
+    "sewing":         "https://images.unsplash.com/photo-1558769132-cb1aea458c5e?w=800&auto=format&fit=crop",
+    "sewing2":        "https://images.unsplash.com/photo-1512436991641-6745cdb1723f?w=800&auto=format&fit=crop",
+    "city_walk":      "https://images.unsplash.com/photo-1524413840807-0c3cb6fa808d?w=800&auto=format&fit=crop",
+    "city_walk2":     "https://images.unsplash.com/photo-1514890547357-a9ee288728e0?w=800&auto=format&fit=crop",
+    "moving":         "https://images.unsplash.com/photo-1600585152220-90363fe7e115?w=800&auto=format&fit=crop",
+    "film":           "https://images.unsplash.com/photo-1489599849927-2ee91cede3ba?w=800&auto=format&fit=crop",
+    "running":        "https://images.unsplash.com/photo-1476480862126-209bfaa8edc8?w=800&auto=format&fit=crop",
+    "running2":       "https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=800&auto=format&fit=crop",
+    "music":          "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?w=800&auto=format&fit=crop",
+    "music2":         "https://images.unsplash.com/photo-1465847899084-d164df4dedc6?w=800&auto=format&fit=crop",
+    "cat":            "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=800&auto=format&fit=crop",
+    "plants":         "https://images.unsplash.com/photo-1463936575829-25148e1db1b8?w=800&auto=format&fit=crop",
+    "plants2":        "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&auto=format&fit=crop",
+    "cv":             "https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=800&auto=format&fit=crop",
+    "market":         "https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=800&auto=format&fit=crop",
+    "izmir":          "https://images.unsplash.com/photo-1589561454226-796a8aa89b05?w=800&auto=format&fit=crop",
+    "ankara":         "https://images.unsplash.com/photo-1591637333184-19aa84b3e01f?w=800&auto=format&fit=crop",
+    "surf":           "https://images.unsplash.com/photo-1502680390469-be75c86b636f?w=800&auto=format&fit=crop",
+    "surf2":          "https://images.unsplash.com/photo-1455729552865-3658a5d39692?w=800&auto=format&fit=crop",
+    "beekeeping":     "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=800&auto=format&fit=crop",
+    "beekeeping2":    "https://images.unsplash.com/photo-1593642632559-0c6d3fc62b89?w=800&auto=format&fit=crop",
+    "ceramics":       "https://images.unsplash.com/photo-1565193566173-7a0ee3dbe261?w=800&auto=format&fit=crop",
+    "ceramics2":      "https://images.unsplash.com/photo-1606425271394-c3ca9aa1fc06?w=800&auto=format&fit=crop",
+    "olive":          "https://images.unsplash.com/photo-1474979266404-7eaacbcd87c5?w=800&auto=format&fit=crop",
+    "hike":           "https://images.unsplash.com/photo-1551632811-561732d1e306?w=800&auto=format&fit=crop",
+    "hike2":          "https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=800&auto=format&fit=crop",
+    # Event images
+    "workshop":       "https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?w=800&auto=format&fit=crop",
+    "breakfast":      "https://images.unsplash.com/photo-1533089860892-a7c6f0a88666?w=800&auto=format&fit=crop",
+    "park":           "https://images.unsplash.com/photo-1533044309907-0fa3413da946?w=800&auto=format&fit=crop",
+    "cinema":         "https://images.unsplash.com/photo-1517604931442-7e0c8ed2963c?w=800&auto=format&fit=crop",
+    "trail":          "https://images.unsplash.com/photo-1551632811-561732d1e306?w=800&auto=format&fit=crop",
+    "picnic":         "https://images.unsplash.com/photo-1526401485004-46910ecc8e51?w=800&auto=format&fit=crop",
+    "bazaar":         "https://images.unsplash.com/photo-1555400038-63f5ba517a47?w=800&auto=format&fit=crop",
+    "concert":        "https://images.unsplash.com/photo-1501386761578-eaa54b4c6bec?w=800&auto=format&fit=crop",
+    # Community covers & avatars
+    "repair_cover":   "https://images.unsplash.com/photo-1581092160607-ee22621dd758?w=1200&auto=format&fit=crop",
     "language_cover": "https://images.unsplash.com/photo-1456513080510-7bf3a84b82f8?w=1200&auto=format&fit=crop",
-    "garden_cover": "https://images.unsplash.com/photo-1523348837708-15d4a09cfac2?w=1200&auto=format&fit=crop",
-    "avatar1":      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&auto=format&fit=crop",
-    "avatar2":      "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&auto=format&fit=crop",
-    "avatar3":      "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&auto=format&fit=crop",
-    "avatar4":      "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=200&auto=format&fit=crop",
-    "avatar5":      "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&auto=format&fit=crop",
+    "garden_cover":   "https://images.unsplash.com/photo-1523348837708-15d4a09cfac2?w=1200&auto=format&fit=crop",
+    "film_cover":     "https://images.unsplash.com/photo-1485846234645-a62644f84728?w=1200&auto=format&fit=crop",
+    "running_cover":  "https://images.unsplash.com/photo-1571008887538-b36bb32f4571?w=1200&auto=format&fit=crop",
+    "books":          "https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800&auto=format&fit=crop",
+    "garden":         "https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?w=800&auto=format&fit=crop",
+    # Avatars
+    "avatar1":        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&auto=format&fit=crop",
+    "avatar2":        "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&auto=format&fit=crop",
+    "avatar3":        "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&auto=format&fit=crop",
+    "avatar4":        "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=200&auto=format&fit=crop",
+    "avatar5":        "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&auto=format&fit=crop",
 }
 
 
 def now():
     return datetime.now(timezone.utc)
+
+
+def days(n):
+    return now() + timedelta(days=n)
 
 
 async def clear_seed_data(db):
@@ -60,10 +115,10 @@ async def seed_users(db) -> dict:
             "email": "alice@hiveseed.dev",
             "hashed_password": hashed,
             "full_name": "Alice Johnson",
-            "bio": "Freelance electronics technician. Love fixing things and helping neighbors.",
+            "bio": "Freelance electronics technician living in Beşiktaş. Love fixing things, reducing waste, and helping neighbours keep their gadgets running longer.",
             "location": "Beşiktaş, Istanbul",
             "roles": ["user"],
-            "timebank_balance": 10.0,
+            "timebank_balance": 18.0,
             "profile_image_url": IMAGES["avatar1"],
             "is_active": True,
             "is_verified": True,
@@ -77,10 +132,10 @@ async def seed_users(db) -> dict:
             "email": "bob@hiveseed.dev",
             "hashed_password": hashed,
             "full_name": "Bob Martinez",
-            "bio": "Software developer looking to learn new skills and exchange services.",
+            "bio": "Software developer by day, home baker by night. I moved to Kadıköy two years ago and haven't stopped exploring its neighbourhoods since.",
             "location": "Kadıköy, Istanbul",
             "roles": ["user"],
-            "timebank_balance": 10.0,
+            "timebank_balance": 12.0,
             "profile_image_url": IMAGES["avatar2"],
             "is_active": True,
             "is_verified": True,
@@ -94,10 +149,10 @@ async def seed_users(db) -> dict:
             "email": "ceren@hiveseed.dev",
             "hashed_password": hashed,
             "full_name": "Ceren Yıldız",
-            "bio": "Graphic designer and community enthusiast. Passionate about sustainable living.",
+            "bio": "Graphic designer passionate about sustainable living and slow fashion. I mend, repurpose, and share. Şişli local.",
             "location": "Şişli, Istanbul",
             "roles": ["user"],
-            "timebank_balance": 10.0,
+            "timebank_balance": 9.0,
             "profile_image_url": IMAGES["avatar3"],
             "is_active": True,
             "is_verified": True,
@@ -111,10 +166,10 @@ async def seed_users(db) -> dict:
             "email": "david@hiveseed.dev",
             "hashed_password": hashed,
             "full_name": "David Chen",
-            "bio": "Urban gardener and sustainability advocate. Organising community garden events.",
+            "bio": "Urban farmer, kombucha brewer, and trail runner. I believe in building community one shared meal — or one shared run — at a time.",
             "location": "Kadıköy, Istanbul",
             "roles": ["user"],
-            "timebank_balance": 10.0,
+            "timebank_balance": 15.0,
             "profile_image_url": IMAGES["avatar4"],
             "is_active": True,
             "is_verified": True,
@@ -128,10 +183,10 @@ async def seed_users(db) -> dict:
             "email": "elif@hiveseed.dev",
             "hashed_password": hashed,
             "full_name": "Elif Şahin",
-            "bio": "Language teacher and culture exchange enthusiast. Fluent in English, Turkish, French.",
+            "bio": "Language teacher, film buff, and occasional street photographer. Beyoğlu is my home and I love introducing newcomers to its hidden corners.",
             "location": "Beyoğlu, Istanbul",
             "roles": ["user"],
-            "timebank_balance": 10.0,
+            "timebank_balance": 20.0,
             "profile_image_url": IMAGES["avatar5"],
             "is_active": True,
             "is_verified": True,
@@ -158,20 +213,23 @@ async def seed_communities(db, users: dict) -> dict:
             "name": "Istanbul Repair Cooperative",
             "slug": "istanbul-repair-cooperative",
             "description": (
-                "A community of repair enthusiasts, technicians, and tinkerers based in Istanbul. "
+                "A community of repair enthusiasts, technicians, and tinkerers across Istanbul. "
                 "We share tools, knowledge, and skills to fix electronics, appliances, bicycles, and more. "
-                "Join us to reduce waste and keep things running!"
+                "Our philosophy: if it can be fixed, it shouldn't be thrown away. "
+                "Monthly repair cafés, skill-sharing sessions, and a growing library of spare parts."
             ),
             "founder_id": alice,
             "tags": [
                 {"label": "repair", "entityId": ""},
                 {"label": "electronics", "entityId": ""},
                 {"label": "DIY", "entityId": ""},
+                {"label": "sustainability", "entityId": ""},
             ],
             "rules": [
-                "Be respectful and patient with fellow members.",
-                "Share knowledge freely — this community thrives on generosity.",
-                "No commercial advertising.",
+                "Be respectful and patient — everyone starts somewhere.",
+                "Share knowledge freely. This community runs on generosity.",
+                "No commercial advertising or selling of services.",
+                "Return borrowed tools within one week.",
             ],
             "avatar_url": IMAGES["workshop"],
             "cover_image_url": IMAGES["repair_cover"],
@@ -185,8 +243,9 @@ async def seed_communities(db, users: dict) -> dict:
             "slug": "language-exchange-hub",
             "description": (
                 "Connect with language learners and native speakers across Istanbul. "
-                "Practice conversational skills, share cultural insights, and build friendships "
-                "through language. All levels welcome."
+                "We meet in cafés, parks, and online to practise languages, share cultures, and make friends. "
+                "Current active languages: Turkish, English, French, Spanish, German, Japanese. "
+                "All levels welcome — the goal is conversation, not perfection."
             ),
             "founder_id": elif_,
             "tags": [
@@ -195,9 +254,10 @@ async def seed_communities(db, users: dict) -> dict:
                 {"label": "culture", "entityId": ""},
             ],
             "rules": [
-                "Respect all languages and cultures.",
-                "Sessions should be balanced — practice both languages equally.",
-                "Keep conversations inclusive and welcoming.",
+                "Respect all languages and cultures equally.",
+                "Balance your sessions — give as much as you receive.",
+                "Be on time. Other members have organised their schedule around you.",
+                "Keep it inclusive — no politics or divisive topics.",
             ],
             "avatar_url": IMAGES["books"],
             "cover_image_url": IMAGES["language_cover"],
@@ -210,23 +270,83 @@ async def seed_communities(db, users: dict) -> dict:
             "name": "Kadikoy Garden Collective",
             "slug": "kadikoy-garden-collective",
             "description": (
-                "A grassroots collective of urban gardeners in the Kadıköy district. "
-                "We share seeds, tools, gardening tips, and organise seasonal planting days. "
-                "Growing food, community, and sustainability together."
+                "A grassroots collective of urban gardeners rooted in the Kadıköy district. "
+                "We share seeds, tools, compost, and knowledge. We grow food on balconies, rooftops, "
+                "and shared plots. We believe food sovereignty begins at the neighbourhood level. "
+                "Beginners always welcome — we have experienced growers who love teaching."
             ),
             "founder_id": david,
             "tags": [
                 {"label": "gardening", "entityId": ""},
-                {"label": "nature", "entityId": ""},
+                {"label": "urban farming", "entityId": ""},
                 {"label": "sustainability", "entityId": ""},
+                {"label": "food", "entityId": ""},
             ],
             "rules": [
-                "Share surplus seeds and produce with members.",
-                "Volunteer for at least one community garden day per season.",
-                "No synthetic pesticides in shared garden spaces.",
+                "Share surplus seeds and produce with members before selling or discarding.",
+                "Volunteer for at least one community work day per season.",
+                "No synthetic pesticides or herbicides in shared spaces.",
+                "Label and date anything you leave in the communal seed library.",
             ],
             "avatar_url": IMAGES["garden"],
             "cover_image_url": IMAGES["garden_cover"],
+            "created_at": now(),
+            "updated_at": now(),
+            "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "name": "Moda Film Club",
+            "slug": "moda-film-club",
+            "description": (
+                "A neighbourhood cinema collective based in the Moda quarter of Kadıköy. "
+                "We host outdoor screenings, rooftop film nights, and post-film discussions. "
+                "Curated around world cinema, Turkish classics, and documentary. "
+                "No membership fee — just show up, watch, and talk about what you saw."
+            ),
+            "founder_id": elif_,
+            "tags": [
+                {"label": "film", "entityId": ""},
+                {"label": "cinema", "entityId": ""},
+                {"label": "culture", "entityId": ""},
+                {"label": "community", "entityId": ""},
+            ],
+            "rules": [
+                "Phones on silent during screenings — no exceptions.",
+                "Post-film discussion is the heart of this club. Please stay.",
+                "Everyone's interpretation is valid. Disagree respectfully.",
+                "Help with setup and takedown when you can.",
+            ],
+            "avatar_url": IMAGES["film"],
+            "cover_image_url": IMAGES["film_cover"],
+            "created_at": now(),
+            "updated_at": now(),
+            "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "name": "Bosphorus Trail Runners",
+            "slug": "bosphorus-trail-runners",
+            "description": (
+                "A running community that explores Istanbul on foot — coastal paths, forest trails, "
+                "historic streets, and everything in between. Weekly group runs, monthly longer routes, "
+                "and year-round encouragement. All paces welcome. The rule: no one runs alone."
+            ),
+            "founder_id": david,
+            "tags": [
+                {"label": "running", "entityId": ""},
+                {"label": "trail", "entityId": ""},
+                {"label": "outdoors", "entityId": ""},
+                {"label": "fitness", "entityId": ""},
+            ],
+            "rules": [
+                "No one gets left behind — the group waits at every junction.",
+                "Always let someone know your route when running solo.",
+                "Leave no trace on trails — carry out what you carry in.",
+                "Encourage slower runners. Speed comes later.",
+            ],
+            "avatar_url": IMAGES["running"],
+            "cover_image_url": IMAGES["running_cover"],
             "created_at": now(),
             "updated_at": now(),
             "seed_marker": SEED_MARKER,
@@ -236,43 +356,59 @@ async def seed_communities(db, users: dict) -> dict:
     await db["communities"].insert_many(communities)
     print(f"  inserted {len(communities)} communities")
 
-    repair_id = communities[0]["_id"]
+    repair_id   = communities[0]["_id"]
     language_id = communities[1]["_id"]
-    garden_id = communities[2]["_id"]
+    garden_id   = communities[2]["_id"]
+    film_id     = communities[3]["_id"]
+    running_id  = communities[4]["_id"]
 
     memberships = [
         # Istanbul Repair Cooperative
-        {"_id": ObjectId(), "community_id": repair_id, "user_id": alice, "role": "founder", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": repair_id, "user_id": bob, "role": "moderator", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": repair_id, "user_id": ceren, "role": "member", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": repair_id, "user_id": alice,  "role": "founder",   "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": repair_id, "user_id": bob,    "role": "moderator", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": repair_id, "user_id": ceren,  "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": repair_id, "user_id": david,  "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
         # Language Exchange Hub
-        {"_id": ObjectId(), "community_id": language_id, "user_id": elif_, "role": "founder", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": language_id, "user_id": david, "role": "member", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": language_id, "user_id": elif_, "role": "founder",  "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": language_id, "user_id": david, "role": "member",   "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": language_id, "user_id": bob,   "role": "member",   "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
         # Kadikoy Garden Collective
-        {"_id": ObjectId(), "community_id": garden_id, "user_id": david, "role": "founder", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": garden_id, "user_id": alice, "role": "member", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": garden_id, "user_id": bob, "role": "member", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
-        {"_id": ObjectId(), "community_id": garden_id, "user_id": ceren, "role": "member", "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": garden_id, "user_id": david,  "role": "founder",   "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": garden_id, "user_id": alice,  "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": garden_id, "user_id": bob,    "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": garden_id, "user_id": ceren,  "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        # Moda Film Club
+        {"_id": ObjectId(), "community_id": film_id, "user_id": elif_,   "role": "founder",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": film_id, "user_id": ceren,   "role": "moderator",  "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": film_id, "user_id": alice,   "role": "member",     "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": film_id, "user_id": bob,     "role": "member",     "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        # Bosphorus Trail Runners
+        {"_id": ObjectId(), "community_id": running_id, "user_id": david, "role": "founder",   "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": running_id, "user_id": bob,   "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
+        {"_id": ObjectId(), "community_id": running_id, "user_id": elif_, "role": "member",    "status": "active", "joined_at": now(), "seed_marker": SEED_MARKER},
     ]
 
     await db["community_memberships"].insert_many(memberships)
     print(f"  inserted {len(memberships)} memberships")
 
     return {
-        "repair": repair_id,
+        "repair":   repair_id,
         "language": language_id,
-        "garden": garden_id,
+        "garden":   garden_id,
+        "film":     film_id,
+        "running":  running_id,
     }
 
 
 async def seed_services(db, users: dict):
     alice = users["alice_seed"]
-    bob = users["bob_seed"]
+    bob   = users["bob_seed"]
     ceren = users["ceren_seed"]
     david = users["david_seed"]
     elif_ = users["elif_seed"]
 
     services = [
+        # ── OFFERS ──────────────────────────────────────────────────────────────
         {
             "_id": ObjectId(),
             "user_id": alice,
@@ -280,92 +416,366 @@ async def seed_services(db, users: dict):
             "description": (
                 "I can diagnose and repair most laptop issues — hardware faults, screen replacements, "
                 "keyboard repairs, battery swaps, and general troubleshooting. Bring your laptop and "
-                "I'll have it running in no time. Years of experience with all major brands."
+                "I'll have it running in no time. Years of experience with all major brands (Apple, Lenovo, HP, ASUS). "
+                "I'll also give you an honest assessment of whether a repair is worth it before we start."
             ),
             "category": "Technology",
-            "tags": [{"label": "repair", "entityId": ""}, {"label": "electronics", "entityId": ""}],
+            "tags": [{"label": "repair", "entityId": ""}, {"label": "electronics", "entityId": ""}, {"label": "laptop", "entityId": ""}],
             "service_type": "offer",
             "status": "active",
             "estimated_duration": 2.0,
             "max_participants": 1,
-            "location": {
-                "type": "Point",
-                "coordinates": [29.00, 41.04],
-                "address": "Beşiktaş, Istanbul",
-            },
+            "location": {"type": "Point", "coordinates": [29.00, 41.04], "address": "Beşiktaş, Istanbul"},
             "is_remote": False,
             "scheduling_type": "open",
             "open_availability": "Weekday evenings and weekends",
-            "image_urls": [IMAGES["laptop"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "image_urls": [IMAGES["laptop"], IMAGES["laptop2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": bob,
+            "title": "Sourdough Bread Baking Class",
+            "description": (
+                "Learn to bake a proper sourdough loaf from scratch — starter maintenance, stretch-and-fold technique, "
+                "shaping, scoring, and baking in a Dutch oven. We'll bake together in my kitchen in Kadıköy. "
+                "You leave with a loaf you made yourself, a portion of live starter, and the recipe. "
+                "Suitable for complete beginners. All ingredients provided."
+            ),
+            "category": "Food & Drink",
+            "tags": [{"label": "baking", "entityId": ""}, {"label": "sourdough", "entityId": ""}, {"label": "food", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 4.0,
+            "max_participants": 2,
+            "location": {"type": "Point", "coordinates": [29.02, 40.99], "address": "Kadıköy, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "recurring",
+            "recurring_pattern": {"days": ["Saturday"], "time": "10:00"},
+            "image_urls": [IMAGES["bread"], IMAGES["bread2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": elif_,
             "title": "English Conversation Practice",
             "description": (
-                "Native-level English conversation sessions for intermediate and advanced learners. "
-                "We can discuss current events, practice job interview skills, work through grammar, "
-                "or just have a casual chat. Sessions tailored to your goals."
+                "Native-level English conversation sessions tailored to your goals. "
+                "We can discuss current events, do job interview prep, work on pronunciation, "
+                "or just have a relaxed chat. I adapt to your level and interests — no textbooks, no homework. "
+                "Sessions via video call. Consistent practice is more valuable than cramming."
             ),
             "category": "Education",
-            "tags": [{"label": "english", "entityId": ""}, {"label": "language", "entityId": ""}],
+            "tags": [{"label": "english", "entityId": ""}, {"label": "language", "entityId": ""}, {"label": "speaking", "entityId": ""}],
             "service_type": "offer",
             "status": "active",
             "estimated_duration": 1.0,
             "max_participants": 2,
-            "location": {
-                "type": "Point",
-                "coordinates": [28.97, 41.03],
-                "address": "Online",
-            },
+            "location": {"type": "Point", "coordinates": [28.97, 41.03], "address": "Online"},
             "is_remote": True,
             "scheduling_type": "recurring",
             "recurring_pattern": {"days": ["Monday", "Wednesday", "Friday"], "time": "19:00"},
-            "image_urls": [IMAGES["conversation"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "image_urls": [IMAGES["conversation"], IMAGES["conversation2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": david,
-            "title": "Garden Design & Planting",
+            "title": "Balcony & Container Garden Design",
             "description": (
-                "Help designing balcony gardens, container gardens, or small outdoor plots. "
-                "I can assist with plant selection for Istanbul's climate, soil preparation, "
-                "companion planting, and seasonal rotation. Sustainable, no-dig methods preferred."
+                "Struggling to make your balcony or windowsill work as a garden? I'll visit your space, "
+                "assess sunlight and wind conditions, and design a planting layout that actually produces food. "
+                "Speciality: Istanbul's micro-climates, companion planting, and low-water methods. "
+                "I'll bring a starter kit of seedlings from my own garden to get you going immediately."
             ),
             "category": "Home & Garden",
-            "tags": [{"label": "gardening", "entityId": ""}, {"label": "sustainability", "entityId": ""}],
+            "tags": [{"label": "gardening", "entityId": ""}, {"label": "urban farming", "entityId": ""}, {"label": "sustainability", "entityId": ""}],
             "service_type": "offer",
             "status": "active",
             "estimated_duration": 3.0,
             "max_participants": 1,
-            "location": {
-                "type": "Point",
-                "coordinates": [29.02, 40.99],
-                "address": "Kadıköy, Istanbul",
-            },
+            "location": {"type": "Point", "coordinates": [29.02, 40.99], "address": "Kadıköy, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "open",
+            "open_availability": "Weekend mornings",
+            "image_urls": [IMAGES["gardening"], IMAGES["gardening2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": ceren,
+            "title": "Visible Mending & Clothes Repair",
+            "description": (
+                "Bring your torn jeans, worn elbows, or broken zips. I'll repair them using visible mending "
+                "techniques — Japanese sashiko stitching, patchwork, and decorative darning — so the repair "
+                "becomes part of the garment's story rather than something to hide. "
+                "Sessions in my Şişli studio. Bring up to 3 garments. All materials provided."
+            ),
+            "category": "Fashion & Crafts",
+            "tags": [{"label": "sewing", "entityId": ""}, {"label": "sustainability", "entityId": ""}, {"label": "slow fashion", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 2.0,
+            "max_participants": 3,
+            "location": {"type": "Point", "coordinates": [28.99, 41.06], "address": "Şişli, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "recurring",
+            "recurring_pattern": {"days": ["Sunday"], "time": "14:00"},
+            "image_urls": [IMAGES["sewing"], IMAGES["sewing2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Beyoğlu Hidden Gems Walking Tour",
+            "description": (
+                "A two-hour neighbourhood walk through the parts of Beyoğlu most visitors and even many locals never find. "
+                "We'll visit a 19th-century Greek Orthodox church, a passage with surviving art deco tiles, "
+                "the best börek spot on a street with no name, and a rooftop with an unobstructed Bosphorus view. "
+                "Groups of 1–4 people. Entirely on foot, comfortable shoes recommended."
+            ),
+            "category": "Local Experiences",
+            "tags": [{"label": "walking tour", "entityId": ""}, {"label": "history", "entityId": ""}, {"label": "local", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 2.0,
+            "max_participants": 4,
+            "location": {"type": "Point", "coordinates": [28.975, 41.033], "address": "Beyoğlu, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "recurring",
+            "recurring_pattern": {"days": ["Saturday", "Sunday"], "time": "10:30"},
+            "image_urls": [IMAGES["city_walk"], IMAGES["city_walk2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Kombucha & Fermentation Workshop",
+            "description": (
+                "I've been brewing kombucha, kefir, and lacto-fermented vegetables for four years. "
+                "In this hands-on session you'll brew your first batch of kombucha from scratch, "
+                "learn about the SCOBY lifecycle, and make a jar of lacto-fermented vegetables to take home. "
+                "We'll also taste five different brews at various fermentation stages. "
+                "All equipment and cultures provided. My kitchen in Kadıköy."
+            ),
+            "category": "Food & Drink",
+            "tags": [{"label": "fermentation", "entityId": ""}, {"label": "kombucha", "entityId": ""}, {"label": "health", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 3.0,
+            "max_participants": 3,
+            "location": {"type": "Point", "coordinates": [29.02, 40.99], "address": "Kadıköy, Istanbul"},
             "is_remote": False,
             "scheduling_type": "specific",
-            "specific_date": (datetime.now() + timedelta(days=3)).strftime("%Y-%m-%d"),
-            "specific_time": "10:00",
-            "image_urls": [IMAGES["gardening"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "specific_date": (datetime.now() + timedelta(days=12)).strftime("%Y-%m-%d"),
+            "specific_time": "11:00",
+            "image_urls": [IMAGES["fermentation"], IMAGES["fermentation2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
+        {
+            "_id": ObjectId(),
+            "user_id": alice,
+            "title": "Bike Tune-Up & Basic Maintenance",
+            "description": (
+                "I'll give your bike a full tune-up — brake adjustment, gear indexing, chain lubrication, "
+                "tyre pressure check, and bolt torque. I'll also teach you the basics so you can handle "
+                "minor issues on your own next time. Bring your bike to the small park near Beşiktaş pier. "
+                "I carry a full set of tools. Only parts you need to replace are charged at cost."
+            ),
+            "category": "Transport",
+            "tags": [{"label": "bike", "entityId": ""}, {"label": "repair", "entityId": ""}, {"label": "cycling", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 1.5,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [29.005, 41.043], "address": "Beşiktaş Pier, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "open",
+            "open_availability": "Saturday mornings",
+            "image_urls": [IMAGES["bike"], IMAGES["bike2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": ceren,
+            "title": "CV & Portfolio Review for Creatives",
+            "description": (
+                "I review CVs and portfolios for graphic designers, illustrators, and other creatives "
+                "looking for their first job or switching studios. I'll give honest, specific feedback on "
+                "layout, content, and how well your work is presented. "
+                "Video call session. Send me your materials 24 hours beforehand so I can prepare notes."
+            ),
+            "category": "Career",
+            "tags": [{"label": "CV", "entityId": ""}, {"label": "design", "entityId": ""}, {"label": "career", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 1.0,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [28.99, 41.06], "address": "Online"},
+            "is_remote": True,
+            "scheduling_type": "open",
+            "open_availability": "Weekday evenings",
+            "image_urls": [IMAGES["cv"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": bob,
+            "title": "Morning Run Buddy — Kadıköy Coastal Path",
+            "description": (
+                "Looking for a running partner for early morning runs along the Kadıköy–Moda coastal path. "
+                "I run 3–4 times a week at a comfortable 6:00–6:30 min/km pace, usually 5–8km. "
+                "Running with someone makes it much easier to get out of bed. "
+                "Any pace near mine is fine — we can adjust. Meet at Moda İskele at 7am."
+            ),
+            "category": "Health & Fitness",
+            "tags": [{"label": "running", "entityId": ""}, {"label": "outdoors", "entityId": ""}, {"label": "fitness", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 1.0,
+            "max_participants": 2,
+            "location": {"type": "Point", "coordinates": [29.03, 40.982], "address": "Moda, Kadıköy, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "recurring",
+            "recurring_pattern": {"days": ["Tuesday", "Thursday", "Saturday"], "time": "07:00"},
+            "image_urls": [IMAGES["running"], IMAGES["running2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+
+        # ── OUTSIDE ISTANBUL — OFFERS ────────────────────────────────────────────
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Surf Lesson for Beginners — Alaçatı",
+            "description": (
+                "Alaçatı is one of the best spots in Europe for beginner windsurfers and paddleboarders, "
+                "and I'm there every September. I'll teach you the fundamentals of paddleboarding in the "
+                "calm lagoon: balance, paddling technique, turning, and how to read the water. "
+                "Board and wetsuit provided. Two-hour session, maximum two people at a time. "
+                "Suitable for anyone with no previous experience."
+            ),
+            "category": "Sports & Outdoors",
+            "tags": [{"label": "surf", "entityId": ""}, {"label": "outdoors", "entityId": ""}, {"label": "İzmir", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 2.0,
+            "max_participants": 2,
+            "location": {"type": "Point", "coordinates": [26.377, 38.282], "address": "Alaçatı, İzmir"},
+            "is_remote": False,
+            "scheduling_type": "open",
+            "open_availability": "September weekends",
+            "image_urls": [IMAGES["surf"], IMAGES["surf2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": alice,
+            "title": "Rooftop Beekeeping Introduction — Bodrum",
+            "description": (
+                "I keep three hives on the roof of a family house near Bodrum harbour. "
+                "If you've ever been curious about urban beekeeping — how a hive is structured, "
+                "how to handle bees calmly, how to harvest honey without a suit — this is for you. "
+                "We'll suit up, open a hive together, find the queen, and taste fresh comb honey. "
+                "Available summer months. Maximum 3 people per session."
+            ),
+            "category": "Nature & Animals",
+            "tags": [{"label": "beekeeping", "entityId": ""}, {"label": "nature", "entityId": ""}, {"label": "Bodrum", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 2.5,
+            "max_participants": 3,
+            "location": {"type": "Point", "coordinates": [27.425, 37.034], "address": "Bodrum, Muğla"},
+            "is_remote": False,
+            "scheduling_type": "open",
+            "open_availability": "June–August, flexible",
+            "image_urls": [IMAGES["beekeeping"], IMAGES["beekeeping2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": ceren,
+            "title": "Ceramics Studio Session — Ankara",
+            "description": (
+                "I have access to a ceramics studio in Çankaya, Ankara with a proper kick wheel and kiln. "
+                "I'll guide you through hand-building or wheel-throwing depending on your preference. "
+                "We'll make one piece per session — bowl, mug, or small vase. "
+                "Firing takes a week; I'll post the finished piece to you anywhere in Turkey. "
+                "No experience needed. Clay, tools, and firing included."
+            ),
+            "category": "Arts & Creative",
+            "tags": [{"label": "ceramics", "entityId": ""}, {"label": "crafts", "entityId": ""}, {"label": "Ankara", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 3.0,
+            "max_participants": 2,
+            "location": {"type": "Point", "coordinates": [32.859, 39.920], "address": "Çankaya, Ankara"},
+            "is_remote": False,
+            "scheduling_type": "open",
+            "open_availability": "When visiting Ankara — check with me first",
+            "image_urls": [IMAGES["ceramics"], IMAGES["ceramics2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Olive Harvest Help — Ayvalık",
+            "description": (
+                "My family has a small olive grove near Ayvalık. Every November we harvest by hand — "
+                "it takes four days and we always need extra help. In exchange for a day's work "
+                "you get accommodation, all meals (my mother's cooking is the real reward), "
+                "and a 5-litre tin of cold-press olive oil to take home. "
+                "Hard physical work but deeply satisfying. Arrivals Friday evening, finish Monday afternoon."
+            ),
+            "category": "Agriculture",
+            "tags": [{"label": "olive harvest", "entityId": ""}, {"label": "farm", "entityId": ""}, {"label": "Ayvalık", "entityId": ""}],
+            "service_type": "offer",
+            "status": "active",
+            "estimated_duration": 8.0,
+            "max_participants": 3,
+            "location": {"type": "Point", "coordinates": [26.688, 39.318], "address": "Ayvalık, Balıkesir"},
+            "is_remote": False,
+            "scheduling_type": "specific",
+            "specific_date": (datetime.now() + timedelta(days=190)).strftime("%Y-%m-%d"),
+            "specific_time": "18:00",
+            "image_urls": [IMAGES["olive"], IMAGES["gardening"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+
+        # ── OUTSIDE ISTANBUL — NEEDS ─────────────────────────────────────────────
+        {
+            "_id": ObjectId(),
+            "user_id": bob,
+            "title": "Hiking Guide for Kaçkar Mountains",
+            "description": (
+                "I'm planning a 4-day trek in the Kaçkar Mountains in August and need someone who knows "
+                "the trails well. I'm an experienced hiker but the Kaçkars are new to me. "
+                "Looking for a local guide or someone who's done the main ridge traverse. "
+                "Happy to share costs, cook every evening, and exchange Python tutoring sessions online afterwards."
+            ),
+            "category": "Sports & Outdoors",
+            "tags": [{"label": "hiking", "entityId": ""}, {"label": "mountains", "entityId": ""}, {"label": "Kaçkar", "entityId": ""}],
+            "service_type": "need",
+            "status": "active",
+            "estimated_duration": 8.0,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [41.126, 40.837], "address": "Kaçkar Mountains, Rize"},
+            "is_remote": False,
+            "scheduling_type": "specific",
+            "specific_date": (datetime.now() + timedelta(days=95)).strftime("%Y-%m-%d"),
+            "specific_time": "08:00",
+            "image_urls": [IMAGES["hike"], IMAGES["hike2"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+
+        # ── NEEDS ────────────────────────────────────────────────────────────────
         {
             "_id": ObjectId(),
             "user_id": bob,
             "title": "Python Programming Tutoring",
             "description": (
-                "Looking for someone to help me level up my Python skills — particularly data structures, "
-                "OOP concepts, and building small projects. I'm a beginner with some basics covered. "
-                "Online sessions preferred, flexible on timing."
+                "Looking for someone patient to help me level up my Python — data structures, OOP, "
+                "and building a small real-world project. I have the basics covered but keep hitting walls. "
+                "Online sessions preferred. Happy to exchange bread baking lessons or running company!"
             ),
             "category": "Education",
             "tags": [{"label": "python", "entityId": ""}, {"label": "programming", "entityId": ""}],
@@ -373,56 +783,45 @@ async def seed_services(db, users: dict):
             "status": "active",
             "estimated_duration": 1.5,
             "max_participants": 1,
-            "location": {
-                "type": "Point",
-                "coordinates": [29.02, 40.99],
-                "address": "Online",
-            },
+            "location": {"type": "Point", "coordinates": [29.02, 40.99], "address": "Online"},
             "is_remote": True,
             "scheduling_type": "open",
             "open_availability": "Weekends, flexible",
             "image_urls": [IMAGES["coding"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": ceren,
             "title": "Furniture Assembly Help",
             "description": (
-                "Need help assembling flat-pack furniture — two IKEA wardrobes and a bookshelf. "
-                "Everything is unpacked and ready, I just need an extra pair of hands and maybe "
-                "someone with more patience for instructions than me!"
+                "I have two IKEA PAX wardrobes and a KALLAX shelf that need assembling. "
+                "Everything is out of the box and the instructions are right there — I just need "
+                "someone with more spatial patience than me and ideally a power drill. "
+                "I'll make lunch. Şişli, easy parking on the street."
             ),
             "category": "Home & Garden",
             "tags": [{"label": "furniture", "entityId": ""}, {"label": "DIY", "entityId": ""}],
             "service_type": "need",
             "status": "active",
-            "estimated_duration": 2.0,
+            "estimated_duration": 3.0,
             "max_participants": 1,
-            "location": {
-                "type": "Point",
-                "coordinates": [28.99, 41.06],
-                "address": "Şişli, Istanbul",
-            },
+            "location": {"type": "Point", "coordinates": [28.99, 41.06], "address": "Şişli, Istanbul"},
             "is_remote": False,
             "scheduling_type": "specific",
             "specific_date": (datetime.now() + timedelta(days=6)).strftime("%Y-%m-%d"),
-            "specific_time": "14:00",
+            "specific_time": "11:00",
             "image_urls": [IMAGES["furniture"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": alice,
             "title": "Portrait Photography Session",
             "description": (
-                "Looking for a photographer to take some professional-style portraits for my updated "
-                "LinkedIn and portfolio. Outdoor location preferred — somewhere in Beyoğlu or Karaköy. "
-                "Happy to discuss styling and location in advance."
+                "Need updated photos for my LinkedIn and portfolio — professional but not stiff. "
+                "I'd love outdoor shots somewhere in Beyoğlu or Karaköy with natural light. "
+                "Happy to plan the location together. Weekends preferred, morning light is ideal."
             ),
             "category": "Arts & Creative",
             "tags": [{"label": "photography", "entityId": ""}, {"label": "portrait", "entityId": ""}],
@@ -430,18 +829,83 @@ async def seed_services(db, users: dict):
             "status": "active",
             "estimated_duration": 2.0,
             "max_participants": 1,
-            "location": {
-                "type": "Point",
-                "coordinates": [28.97, 41.03],
-                "address": "Beyoğlu, Istanbul",
-            },
+            "location": {"type": "Point", "coordinates": [28.97, 41.03], "address": "Beyoğlu, Istanbul"},
             "is_remote": False,
             "scheduling_type": "open",
             "open_availability": "Weekend mornings",
             "image_urls": [IMAGES["photography"]],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Someone to Water My Plants While I'm Away",
+            "description": (
+                "I'll be in Ankara for 10 days and have about 30 indoor plants that need watering "
+                "every 2–3 days. My flat is in Beyoğlu, close to the metro. "
+                "Very easy — I'll leave written instructions for each plant. "
+                "Happy to return the favour or exchange for language sessions."
+            ),
+            "category": "Home & Garden",
+            "tags": [{"label": "plants", "entityId": ""}, {"label": "home care", "entityId": ""}],
+            "service_type": "need",
+            "status": "active",
+            "estimated_duration": 0.5,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [28.975, 41.033], "address": "Beyoğlu, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "specific",
+            "specific_date": (datetime.now() + timedelta(days=8)).strftime("%Y-%m-%d"),
+            "specific_time": "09:00",
+            "image_urls": [IMAGES["plants"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Help Moving a Few Large Items",
+            "description": (
+                "I'm rearranging my flat and need help moving a heavy bookshelf and a solid wood dining table "
+                "between rooms. Nothing is going up or down stairs — just within one floor. "
+                "Should take under an hour with two people. Kadıköy, close to the market. "
+                "I'll cook dinner for anyone who helps."
+            ),
+            "category": "Home & Garden",
+            "tags": [{"label": "moving", "entityId": ""}, {"label": "help", "entityId": ""}],
+            "service_type": "need",
+            "status": "active",
+            "estimated_duration": 1.0,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [29.02, 40.99], "address": "Kadıköy, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "specific",
+            "specific_date": (datetime.now() + timedelta(days=4)).strftime("%Y-%m-%d"),
+            "specific_time": "16:00",
+            "image_urls": [IMAGES["moving"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": bob,
+            "title": "Neighbourhood Grocery Run for My Elderly Neighbour",
+            "description": (
+                "My upstairs neighbour, Mrs Fatma (78), has trouble walking to the market since her knee surgery. "
+                "I'm looking for someone willing to add her shopping list to their weekly grocery run — "
+                "she shops at the Migros on Bağdat Caddesi and pays cash on delivery. "
+                "This is a recurring need, ideally weekly. Small list, usually under 20 items."
+            ),
+            "category": "Community Care",
+            "tags": [{"label": "elderly care", "entityId": ""}, {"label": "community", "entityId": ""}, {"label": "grocery", "entityId": ""}],
+            "service_type": "need",
+            "status": "active",
+            "estimated_duration": 1.0,
+            "max_participants": 1,
+            "location": {"type": "Point", "coordinates": [29.06, 40.97], "address": "Bağdat Caddesi, Kadıköy, Istanbul"},
+            "is_remote": False,
+            "scheduling_type": "recurring",
+            "recurring_pattern": {"days": ["Saturday"], "time": "11:00"},
+            "image_urls": [IMAGES["market"]],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
     ]
 
@@ -451,7 +915,8 @@ async def seed_services(db, users: dict):
 
 async def seed_events(db, users: dict, communities: dict):
     alice = users["alice_seed"]
-    bob = users["bob_seed"]
+    bob   = users["bob_seed"]
+    ceren = users["ceren_seed"]
     david = users["david_seed"]
     elif_ = users["elif_seed"]
 
@@ -459,94 +924,288 @@ async def seed_events(db, users: dict, communities: dict):
         {
             "_id": ObjectId(),
             "user_id": alice,
-            "title": "Repair Workshop Meetup",
+            "title": "Monthly Repair Café",
             "description": (
-                "Monthly repair workshop open to all community members. Bring your broken items — "
-                "electronics, small appliances, bikes — and we'll fix them together. "
-                "Expert members on hand to guide beginners. Tools and spare parts provided."
+                "Our monthly repair café is open to everyone — members and non-members alike. "
+                "Bring broken electronics, appliances, bikes, or anything else you think might be fixable. "
+                "Skilled volunteers are on hand to help. We've fixed over 200 items in the past year and kept "
+                "them out of landfill. Coffee and tea provided. Donations welcome but never required."
             ),
-            "event_at": now() + timedelta(days=7),
-            "location": "Beşiktaş Community Centre, Istanbul",
-            "latitude": 41.04,
-            "longitude": 29.00,
+            "event_at": days(7),
+            "location": "Beşiktaş Community Centre, Çarşı Mah., Istanbul",
+            "latitude": 41.044, "longitude": 29.005,
             "is_remote": False,
-            "tags": [{"label": "repair", "entityId": ""}, {"label": "workshop", "entityId": ""}],
+            "tags": [{"label": "repair", "entityId": ""}, {"label": "community", "entityId": ""}],
             "community_id": str(communities["repair"]),
-            "image_urls": [IMAGES["workshop"]],
-            "attendee_ids": [],
-            "upvoted_by": [],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "image_urls": [IMAGES["workshop"], IMAGES["coding2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": elif_,
-            "title": "Language Exchange Breakfast",
+            "title": "Sunday Language Exchange Breakfast",
             "description": (
-                "A relaxed Sunday morning language exchange over breakfast at a Kadıköy café. "
-                "Practice Turkish, English, French, or any other language in a friendly, low-pressure "
-                "environment. All levels welcome. Seats limited to 12."
+                "We take over the back room of a Kadıköy café every other Sunday for a relaxed language exchange. "
+                "The format is simple: find a partner at the opposite table, speak their language for 20 minutes, "
+                "then switch. We rotate three times. Ends with everyone at one table and free conversation. "
+                "Active languages this session: Turkish, English, Spanish, French. Seats limited to 14."
             ),
-            "event_at": now() + timedelta(days=14),
-            "location": "Mandabatmaz Café, Kadıköy, Istanbul",
-            "latitude": 40.99,
-            "longitude": 29.02,
+            "event_at": days(13),
+            "location": "Fazıl Bey Kahvesi, Moda Caddesi, Kadıköy",
+            "latitude": 40.987, "longitude": 29.024,
             "is_remote": False,
             "tags": [{"label": "language", "entityId": ""}, {"label": "social", "entityId": ""}],
             "community_id": str(communities["language"]),
             "image_urls": [IMAGES["breakfast"]],
-            "attendee_ids": [],
-            "upvoted_by": [],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": david,
-            "title": "Community Garden Day",
+            "title": "Spring Planting Day at Moda Park",
             "description": (
-                "Spring planting day at Moda Park. We'll be setting up new raised beds, dividing "
-                "perennials, and sowing summer vegetables. Bring gloves if you have them — "
-                "tools, seeds, and compost are provided. Ends with a shared picnic lunch!"
+                "The big one of the year — our spring community planting day. We'll be building two new raised beds, "
+                "dividing overwintered perennials, and sowing tomatoes, courgettes, and herbs together. "
+                "Experienced growers will guide beginners through every step. "
+                "Bring gloves if you have them. Tools, seeds, and compost are provided. "
+                "We end with a shared picnic — please bring something to contribute to the table."
             ),
-            "event_at": now() + timedelta(days=10),
-            "location": "Moda Park, Kadıköy, Istanbul",
-            "latitude": 40.98,
-            "longitude": 29.03,
+            "event_at": days(10),
+            "location": "Moda Park Community Garden, Kadıköy",
+            "latitude": 40.981, "longitude": 29.028,
             "is_remote": False,
             "tags": [{"label": "gardening", "entityId": ""}, {"label": "community", "entityId": ""}],
             "community_id": str(communities["garden"]),
-            "image_urls": [IMAGES["park"]],
-            "attendee_ids": [],
-            "upvoted_by": [],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "image_urls": [IMAGES["park"], IMAGES["gardening2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Rooftop Film Night: Yol (1982)",
+            "description": (
+                "We're screening Yılmaz Güney's Palme d'Or-winning Yol on the rooftop of a building in Moda. "
+                "The film runs 114 minutes. We'll have a 30-minute discussion afterwards. "
+                "Bring a jacket — it gets cool after sunset. Bean bags and cushions provided, "
+                "or bring your own blanket. Subtitles in English and Turkish. Free entry, donation jar for drinks."
+            ),
+            "event_at": days(18),
+            "location": "Moda Rooftop (address shared with RSVP), Kadıköy",
+            "latitude": 40.984, "longitude": 29.026,
+            "is_remote": False,
+            "tags": [{"label": "film", "entityId": ""}, {"label": "cinema", "entityId": ""}, {"label": "outdoor", "entityId": ""}],
+            "community_id": str(communities["film"]),
+            "image_urls": [IMAGES["cinema"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Dawn Run: Bosphorus Coastal Path (10km)",
+            "description": (
+                "We meet at Kalamış Marina at first light and run the coastal path north to Fenerbahçe Park and back — "
+                "about 10km with beautiful Bosphorus views the whole way. Pace 5:45–6:15 per km. "
+                "All levels welcome as long as you can cover the distance comfortably. "
+                "Coffee at Moda afterwards. Bring a water bottle and headlamp just in case."
+            ),
+            "event_at": days(4),
+            "location": "Kalamış Marina, Kadıköy, Istanbul",
+            "latitude": 40.969, "longitude": 29.038,
+            "is_remote": False,
+            "tags": [{"label": "running", "entityId": ""}, {"label": "outdoors", "entityId": ""}],
+            "community_id": str(communities["running"]),
+            "image_urls": [IMAGES["trail"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": ceren,
+            "title": "Mending Circle — Slow Fashion Afternoon",
+            "description": (
+                "A quiet Sunday afternoon for anyone who wants to mend, sew, or just sit and make something. "
+                "Bring a broken item of clothing or a project you've been putting off. "
+                "I'll be there to guide visible mending techniques — sashiko, darning, and patchwork. "
+                "No experience needed. We'll have tea, music, and good company. "
+                "Location: my studio in Şişli, capacity 8 people."
+            ),
+            "event_at": days(9),
+            "location": "Ceren's Studio, Harbiye, Şişli, Istanbul",
+            "latitude": 41.061, "longitude": 28.993,
+            "is_remote": False,
+            "tags": [{"label": "sewing", "entityId": ""}, {"label": "sustainability", "entityId": ""}, {"label": "crafts", "entityId": ""}],
+            "community_id": None,
+            "image_urls": [IMAGES["sewing"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
         {
             "_id": ObjectId(),
             "user_id": bob,
             "title": "Online Python Workshop for Beginners",
             "description": (
-                "A two-hour online workshop covering Python fundamentals: variables, loops, functions, "
-                "and building a small project together. No prior experience needed. "
-                "We'll use an online IDE so nothing to install. Join the link 5 minutes early."
+                "A two-hour workshop covering Python from zero: variables, loops, functions, and a small real project. "
+                "We'll build a simple command-line tool together by the end of the session. "
+                "No installation needed — we'll use an online IDE. "
+                "Limited to 8 participants so everyone gets attention. Session recorded and shared afterwards."
             ),
-            "event_at": now() + timedelta(days=5),
-            "location": None,
-            "latitude": None,
-            "longitude": None,
+            "event_at": days(5),
+            "location": None, "latitude": None, "longitude": None,
             "is_remote": True,
             "tags": [{"label": "python", "entityId": ""}, {"label": "programming", "entityId": ""}, {"label": "beginner", "entityId": ""}],
             "community_id": None,
             "image_urls": [IMAGES["coding"]],
-            "attendee_ids": [],
-            "upvoted_by": [],
-            "created_at": now(),
-            "updated_at": now(),
-            "seed_marker": SEED_MARKER,
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": alice,
+            "title": "Neighbourhood Swap & Share Bazaar",
+            "description": (
+                "A free, no-money swap market in Beşiktaş. Bring things you no longer need — clothes, books, "
+                "kitchenware, plants, tools — and take whatever catches your eye. "
+                "No price tags, no transactions, no waste. Everything left over at the end is donated. "
+                "Also a good excuse to meet your neighbours. Outdoor event, rain contingency plan in place."
+            ),
+            "event_at": days(21),
+            "location": "Beşiktaş Çarşı Square, Istanbul",
+            "latitude": 41.043, "longitude": 29.003,
+            "is_remote": False,
+            "tags": [{"label": "swap", "entityId": ""}, {"label": "community", "entityId": ""}, {"label": "sustainability", "entityId": ""}],
+            "community_id": None,
+            "image_urls": [IMAGES["bazaar"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Acoustic Session: Balcony Concert in Beyoğlu",
+            "description": (
+                "A small acoustic concert on a wide Beyoğlu balcony overlooking the rooftops. "
+                "Three local musicians playing sets of 25 minutes each — folk, jazz, and one surprise. "
+                "Capacity strictly 20 people. Standing room on the balcony and inside by the open door. "
+                "Drinks from the kitchen on a donation basis. One of those evenings that only happens in this city."
+            ),
+            "event_at": days(16),
+            "location": "Private Balcony, Asmalımescit, Beyoğlu (address shared on RSVP)",
+            "latitude": 41.031, "longitude": 28.976,
+            "is_remote": False,
+            "tags": [{"label": "music", "entityId": ""}, {"label": "community", "entityId": ""}, {"label": "local", "entityId": ""}],
+            "community_id": None,
+            "image_urls": [IMAGES["concert"], IMAGES["music2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Fermentation Tasting & Q&A",
+            "description": (
+                "An informal afternoon of tasting and talking about fermented foods. I'll bring twelve "
+                "different ferments: kombuchas at different stages, water kefir, kvass, several lacto-fermented "
+                "vegetables, and a mystery guest ferment. We taste, discuss the process, ask questions. "
+                "No lecture format — just curiosity and conversation. Open garden in Kadıköy, 15 people max."
+            ),
+            "event_at": days(25),
+            "location": "David's Garden, Moda, Kadıköy, Istanbul",
+            "latitude": 40.983, "longitude": 29.027,
+            "is_remote": False,
+            "tags": [{"label": "fermentation", "entityId": ""}, {"label": "food", "entityId": ""}, {"label": "community", "entityId": ""}],
+            "community_id": str(communities["garden"]),
+            "image_urls": [IMAGES["fermentation"], IMAGES["fermentation2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+
+        # ── OUTSIDE ISTANBUL ─────────────────────────────────────────────────────
+        {
+            "_id": ObjectId(),
+            "user_id": david,
+            "title": "Kaçkar Trails Clean-Up Day",
+            "description": (
+                "A volunteer trail clean-up along the Kaçkar ridge, organised with the local hiking association. "
+                "We collect litter, clear overgrown sections, and mark a newly opened side trail. "
+                "Work starts at dawn, finishes mid-afternoon. Free lunch provided by the village. "
+                "No experience needed — just good boots and the desire to give something back to a mountain "
+                "that gives a lot to those who walk it. Transport from Çamlıhemşin arranged on request."
+            ),
+            "event_at": days(60),
+            "location": "Çamlıhemşin, Rize",
+            "latitude": 40.987, "longitude": 41.063,
+            "is_remote": False,
+            "tags": [{"label": "hiking", "entityId": ""}, {"label": "volunteering", "entityId": ""}, {"label": "nature", "entityId": ""}],
+            "community_id": str(communities["running"]),
+            "image_urls": [IMAGES["hike"], IMAGES["hike2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": elif_,
+            "title": "Ayvalık Olive Harvest Weekend",
+            "description": (
+                "Join us for a long weekend in Elif's family olive grove near Ayvalık. "
+                "We harvest by hand, press the olives the same day, and eat together every evening. "
+                "It's hard work but the kind that leaves you feeling genuinely good. "
+                "Accommodation in the family house. Bring work clothes and an appetite. "
+                "Spots limited to 6 people. This event happens once a year — don't miss it."
+            ),
+            "event_at": days(192),
+            "location": "Olive Grove, Ayvalık, Balıkesir",
+            "latitude": 39.318, "longitude": 26.688,
+            "is_remote": False,
+            "tags": [{"label": "harvest", "entityId": ""}, {"label": "farm", "entityId": ""}, {"label": "community", "entityId": ""}],
+            "community_id": str(communities["garden"]),
+            "image_urls": [IMAGES["olive"], IMAGES["gardening"], IMAGES["picnic"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": ceren,
+            "title": "Ankara Design & Craft Fair",
+            "description": (
+                "A two-day craft and design fair in the Kızılay district of Ankara. "
+                "Independent makers, textile artists, ceramic studios, and small-batch food producers. "
+                "I'll have a table showcasing visible mending work and slow fashion pieces. "
+                "Come say hello, browse, and meet the people behind the things. "
+                "Free entry. Saturday and Sunday, 10:00–18:00."
+            ),
+            "event_at": days(35),
+            "location": "Kızılay Meydanı, Çankaya, Ankara",
+            "latitude": 39.919, "longitude": 32.854,
+            "is_remote": False,
+            "tags": [{"label": "crafts", "entityId": ""}, {"label": "design", "entityId": ""}, {"label": "Ankara", "entityId": ""}],
+            "community_id": None,
+            "image_urls": [IMAGES["bazaar"], IMAGES["sewing2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
+        },
+        {
+            "_id": ObjectId(),
+            "user_id": bob,
+            "title": "Alaçatı Open Kitchen: Sourdough Pop-Up",
+            "description": (
+                "I'll be in Alaçatı for a week in September and hosting a one-evening sourdough pop-up "
+                "in the courtyard of a friend's guesthouse. We bake together, eat together, and I send "
+                "everyone home with a portion of starter and the recipe. "
+                "Six people maximum. Bring wine if you like. BYOB otherwise casual."
+            ),
+            "event_at": days(128),
+            "location": "Taş Ev Guesthouse, Alaçatı, İzmir",
+            "latitude": 38.282, "longitude": 26.376,
+            "is_remote": False,
+            "tags": [{"label": "baking", "entityId": ""}, {"label": "food", "entityId": ""}, {"label": "İzmir", "entityId": ""}],
+            "community_id": None,
+            "image_urls": [IMAGES["bread"], IMAGES["bread2"], IMAGES["cooking2"]],
+            "attendee_ids": [], "upvoted_by": [],
+            "created_at": now(), "updated_at": now(), "seed_marker": SEED_MARKER,
         },
     ]
 
@@ -576,8 +1235,8 @@ async def main():
 
     client.close()
     print("\n✓ Mock data seeded successfully")
-    print("  Login with any seed user: password = Test1234!")
-    print("  Users: alice_seed, bob_seed, ceren_seed, david_seed, elif_seed")
+    print("  Login: alice_seed / bob_seed / ceren_seed / david_seed / elif_seed")
+    print("  Password: Test1234!")
 
 
 if __name__ == "__main__":

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { ServiceDetail } from "@/pages/ServiceDetail";
 import { UserDetail } from "@/pages/UserDetail";
 import { Profile } from "@/pages/Profile";
 import { AdminPanel } from "@/pages/AdminPanel";
+import { Settings } from "@/pages/Settings";
 import { Forum } from "@/pages/Forum";
 import { ForumDiscussionDetail } from "@/pages/ForumDiscussionDetail";
 import { ForumEventDetail } from "@/pages/ForumEventDetail";
@@ -180,6 +181,17 @@ function App() {
                         fallbackPath="/?login=true"
                       >
                         <CommunityPostDetail />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/settings"
+                    element={
+                      <ProtectedRoute
+                        requiredRole="user"
+                        fallbackPath="/?login=true"
+                      >
+                        <Settings />
                       </ProtectedRoute>
                     }
                   />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -127,11 +127,20 @@ export function Header() {
                   </IconButton>
                 </Tooltip>
                 <NotificationBell />
-                {(user.role === "admin" || user.role === "moderator") && (
+                {user.role === "admin" || user.role === "moderator" ? (
                   <Tooltip content="Admin Panel">
                     <IconButton
                       onClick={() => navigate("/admin")}
                       variant="outline"
+                    >
+                      <GearIcon className="w-4 h-4" />
+                    </IconButton>
+                  </Tooltip>
+                ) : (
+                  <Tooltip content="Settings">
+                    <IconButton
+                      onClick={() => navigate("/settings")}
+                      variant="ghost"
                     >
                       <GearIcon className="w-4 h-4" />
                     </IconButton>

--- a/frontend/src/components/ui/ActivitySummarySection.tsx
+++ b/frontend/src/components/ui/ActivitySummarySection.tsx
@@ -1,0 +1,644 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, Text, Flex, Badge, Heading, Separator } from "@radix-ui/themes";
+import { ArrowUpIcon, ArrowDownIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { Transaction, RatingDetailed } from "@/types";
+import { StatusBadge } from "@/components/ui/StatusBadge";
+import { RatingStars } from "@/components/ui/RatingStars";
+import { InterestChip } from "@/components/ui/InterestChip";
+import { tagToLabel } from "@/components/ui/ConfirmCompletionModal";
+import { ImageGallery } from "@/components/ui/ImageGallery";
+import { formatDateShort } from "@/utils/utils";
+
+type FilterTab = "all" | "given" | "taken" | "in_progress";
+
+interface ActivitySummarySectionProps {
+  transactions: Transaction[];
+  ratings: RatingDetailed[];
+  currentUserId: string;
+  isLoading: boolean;
+}
+
+interface EnrichedTransaction {
+  tx: Transaction;
+  userRole: "provider" | "requester";
+  rating: RatingDetailed | null;
+  monthKey: string;
+}
+
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+  pending: { label: "Pending", color: "var(--gray-9)" },
+  in_progress: { label: "In Progress", color: "var(--amber-9)" },
+  completed: { label: "Completed", color: "var(--green-9)" },
+  cancelled: { label: "Cancelled", color: "var(--red-9)" },
+  disputed: { label: "Disputed", color: "var(--orange-9)" },
+};
+
+// 4-segment bar colors — given = orange tones, taken = blue tones
+const SEG = {
+  givenOffer: "var(--orange-9)",
+  givenNeed:  "var(--amber-9)",
+  takenOffer: "var(--blue-9)",
+  takenNeed:  "var(--cyan-9)",
+};
+
+function getLastMonths(n: number) {
+  const months: { key: string; label: string }[] = [];
+  const now = new Date();
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    const label = d.toLocaleString("default", { month: "short" });
+    months.push({ key, label });
+  }
+  return months;
+}
+
+function PillButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: "4px 12px",
+        borderRadius: "var(--radius-full)",
+        border: "1px solid",
+        borderColor: active ? "var(--accent-9)" : "var(--gray-5)",
+        backgroundColor: active ? "var(--accent-3)" : "transparent",
+        color: active ? "var(--accent-11)" : "var(--gray-11)",
+        cursor: "pointer",
+        fontSize: "var(--font-size-2)",
+        fontWeight: active ? "600" : "400",
+        transition: "all 0.15s",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ActivitySummarySection({
+  transactions,
+  ratings,
+  currentUserId,
+  isLoading,
+}: ActivitySummarySectionProps) {
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState<FilterTab>("all");
+  const [monthFilter, setMonthFilter] = useState<string | null>(null);
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+
+  const enriched = useMemo<EnrichedTransaction[]>(() => {
+    const ratingMap = new Map<string, RatingDetailed>();
+    for (const r of ratings) ratingMap.set(r.transaction_id, r);
+    return transactions.map((tx) => {
+      const d = new Date(tx.created_at);
+      const monthKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      return {
+        tx,
+        userRole:
+          String(tx.provider_id) === String(currentUserId)
+            ? "provider"
+            : "requester",
+        rating: ratingMap.get(tx._id) ?? null,
+        monthKey,
+      };
+    });
+  }, [transactions, ratings, currentUserId]);
+
+  const filtered = useMemo(() => {
+    let result = enriched;
+    switch (filter) {
+      case "given":    result = result.filter((e) => e.userRole === "provider"); break;
+      case "taken":    result = result.filter((e) => e.userRole === "requester"); break;
+      case "in_progress": result = result.filter((e) => e.tx.status === "in_progress" || e.tx.status === "pending"); break;
+    }
+    if (monthFilter) result = result.filter((e) => e.monthKey === monthFilter);
+    if (tagFilter)   result = result.filter((e) =>
+      e.rating?.tags?.some((t) => tagToLabel(t) === tagFilter)
+    );
+    return result;
+  }, [enriched, filter, monthFilter, tagFilter]);
+
+  const stats = useMemo(() => {
+    const givenAll = enriched.filter((e) => e.userRole === "provider");
+    const takenAll = enriched.filter((e) => e.userRole === "requester");
+    const given    = givenAll.filter((e) => e.tx.status === "completed");
+    const taken    = takenAll.filter((e) => e.tx.status === "completed");
+    const ratedItems = enriched.filter((e) => e.rating !== null);
+    const avgRating =
+      ratedItems.length > 0
+        ? ratedItems.reduce((s, e) => s + (e.rating?.score ?? 0), 0) / ratedItems.length
+        : null;
+
+    const givenStatusCounts = givenAll.reduce((acc, e) => {
+      acc[e.tx.status] = (acc[e.tx.status] || 0) + 1; return acc;
+    }, {} as Record<string, number>);
+    const takenStatusCounts = takenAll.reduce((acc, e) => {
+      acc[e.tx.status] = (acc[e.tx.status] || 0) + 1; return acc;
+    }, {} as Record<string, number>);
+
+    const givenOffers = givenAll.filter((e) => e.rating?.service?.service_type === "offer").length;
+    const givenNeeds  = givenAll.filter((e) => e.rating?.service?.service_type === "need").length;
+    const takenOffers = takenAll.filter((e) => e.rating?.service?.service_type === "offer").length;
+    const takenNeeds  = takenAll.filter((e) => e.rating?.service?.service_type === "need").length;
+
+    return {
+      givenTotal: givenAll.length,
+      givenHours: given.reduce((s, e) => s + e.tx.timebank_hours, 0),
+      takenTotal: takenAll.length,
+      takenHours: taken.reduce((s, e) => s + e.tx.timebank_hours, 0),
+      avgRating, ratedCount: ratedItems.length,
+      givenStatusCounts, takenStatusCounts,
+      givenOffers, givenNeeds, takenOffers, takenNeeds,
+    };
+  }, [enriched]);
+
+  // Monthly data with 4-segment breakdown
+  const monthlyData = useMemo(() => {
+    const months = getLastMonths(6);
+    return months.map(({ key, label }) => {
+      const inMonth = enriched.filter((e) => e.monthKey === key);
+      const givenOffer  = inMonth.filter((e) => e.userRole === "provider"  && e.rating?.service?.service_type === "offer").length;
+      const givenNeed   = inMonth.filter((e) => e.userRole === "provider"  && e.rating?.service?.service_type === "need").length;
+      const givenUnk    = inMonth.filter((e) => e.userRole === "provider"  && !e.rating?.service?.service_type).length;
+      const takenOffer  = inMonth.filter((e) => e.userRole === "requester" && e.rating?.service?.service_type === "offer").length;
+      const takenNeed   = inMonth.filter((e) => e.userRole === "requester" && e.rating?.service?.service_type === "need").length;
+      const takenUnk    = inMonth.filter((e) => e.userRole === "requester" && !e.rating?.service?.service_type).length;
+      const given = givenOffer + givenNeed + givenUnk;
+      const taken = takenOffer + takenNeed + takenUnk;
+      return { key, label, givenOffer, givenNeed, givenUnk, takenOffer, takenNeed, takenUnk, given, taken, total: given + taken };
+    });
+  }, [enriched]);
+  const maxMonthTotal = Math.max(...monthlyData.map((m) => m.total), 1);
+
+  // Top feedback tags — clickable
+  const topTags = useMemo(() => {
+    const tagCounts: Record<string, number> = {};
+    for (const r of ratings) {
+      for (const tag of r.tags ?? []) {
+        const label = tagToLabel(tag);
+        tagCounts[label] = (tagCounts[label] || 0) + 1;
+      }
+    }
+    return Object.entries(tagCounts).sort((a, b) => b[1] - a[1]).slice(0, 6);
+  }, [ratings]);
+
+  const inProgressCount = enriched.filter(
+    (e) => e.tx.status === "in_progress" || e.tx.status === "pending",
+  ).length;
+
+  const statusOrder = ["in_progress", "completed", "pending", "cancelled", "disputed"];
+  const hasActiveFilter = monthFilter !== null || tagFilter !== null;
+
+  const clearFilters = () => { setMonthFilter(null); setTagFilter(null); };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Heading size="5">Activity Summary</Heading>
+        <Card className="p-6 text-center"><Text color="gray">Loading activity...</Text></Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <Heading size="5">Activity Summary</Heading>
+
+      {enriched.length === 0 ? (
+        <Card className="p-6 text-center"><Text color="gray">No activity yet</Text></Card>
+      ) : (
+        <>
+          {/* ── Charts card ── */}
+          <Flex direction="column" gap="5">
+
+            {/* Stat pills — clickable */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* Given pill */}
+              <div
+                  className="rounded-lg px-4 py-3 cursor-pointer transition-all"
+                  style={{
+                    background: filter === "given" ? "var(--orange-a3)" : "var(--gray-a2)",
+                    outline: filter === "given" ? "1.5px solid var(--orange-8)" : "none",
+                  }}
+                  onClick={() => setFilter(filter === "given" ? "all" : "given")}
+                  role="button"
+                  aria-pressed={filter === "given"}
+              >
+                <Text size="1" color="gray" className="block mb-1">Services Given</Text>
+                <Flex align="center" gap="2" wrap="wrap">
+                  <Text size="4" weight="bold">{stats.givenTotal}</Text>
+                  <Badge size="1" color="orange" variant="soft">{stats.givenHours.toFixed(1)} hrs</Badge>
+                </Flex>
+                {(stats.givenOffers > 0 || stats.givenNeeds > 0) && (
+                    <Flex gap="3" wrap="wrap" className="mt-1">
+                      {stats.givenOffers > 0 && (
+                          <Flex align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: SEG.givenOffer }} />
+                            <Text size="1" color="gray">{stats.givenOffers} Offer{stats.givenOffers !== 1 ? "s" : ""}</Text>
+                          </Flex>
+                      )}
+                      {stats.givenNeeds > 0 && (
+                          <Flex align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: SEG.givenNeed }} />
+                            <Text size="1" color="gray">{stats.givenNeeds} Need{stats.givenNeeds !== 1 ? "s" : ""}</Text>
+                          </Flex>
+                      )}
+                    </Flex>
+                )}
+                {Object.keys(stats.givenStatusCounts).length > 0 && (
+                    <Flex gap="3" wrap="wrap" className="mt-2">
+                      {statusOrder.filter((s) => stats.givenStatusCounts[s] > 0).map((s) => (
+                          <Flex key={s} align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: STATUS_CONFIG[s]?.color ?? "var(--gray-9)" }} />
+                            <Text size="1" color="gray">{STATUS_CONFIG[s]?.label ?? s} ({stats.givenStatusCounts[s]})</Text>
+                          </Flex>
+                      ))}
+                    </Flex>
+                )}
+              </div>
+
+              {/* Taken pill */}
+              <div
+                  className="rounded-lg px-4 py-3 cursor-pointer transition-all"
+                  style={{
+                    background: filter === "taken" ? "var(--blue-a3)" : "var(--gray-a2)",
+                    outline: filter === "taken" ? "1.5px solid var(--blue-8)" : "none",
+                  }}
+                  onClick={() => setFilter(filter === "taken" ? "all" : "taken")}
+                  role="button"
+                  aria-pressed={filter === "taken"}
+              >
+                <Text size="1" color="gray" className="block mb-1">Services Taken</Text>
+                <Flex align="center" gap="2" wrap="wrap">
+                  <Text size="4" weight="bold">{stats.takenTotal}</Text>
+                  <Badge size="1" color="blue" variant="soft">{stats.takenHours.toFixed(1)} hrs</Badge>
+                </Flex>
+                {(stats.takenOffers > 0 || stats.takenNeeds > 0) && (
+                    <Flex gap="3" wrap="wrap" className="mt-1">
+                      {stats.takenOffers > 0 && (
+                          <Flex align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: SEG.takenOffer }} />
+                            <Text size="1" color="gray">{stats.takenOffers} Offer{stats.takenOffers !== 1 ? "s" : ""}</Text>
+                          </Flex>
+                      )}
+                      {stats.takenNeeds > 0 && (
+                          <Flex align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: SEG.takenNeed }} />
+                            <Text size="1" color="gray">{stats.takenNeeds} Need{stats.takenNeeds !== 1 ? "s" : ""}</Text>
+                          </Flex>
+                      )}
+                    </Flex>
+                )}
+                {Object.keys(stats.takenStatusCounts).length > 0 && (
+                    <Flex gap="3" wrap="wrap" className="mt-2">
+                      {statusOrder.filter((s) => stats.takenStatusCounts[s] > 0).map((s) => (
+                          <Flex key={s} align="center" gap="1">
+                            <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: STATUS_CONFIG[s]?.color ?? "var(--gray-9)" }} />
+                            <Text size="1" color="gray">{STATUS_CONFIG[s]?.label ?? s} ({stats.takenStatusCounts[s]})</Text>
+                          </Flex>
+                      ))}
+                    </Flex>
+                )}
+                {stats.avgRating !== null && (
+                    <Flex align="center" gap="2" className="mt-2">
+                      <RatingStars value={Math.round(stats.avgRating * 10) / 10} readonly size={13} />
+                      <Text size="1" color="gray">{stats.avgRating.toFixed(1)} avg ({stats.ratedCount} rated)</Text>
+                    </Flex>
+                )}
+              </div>
+            </div>
+
+            {/* Monthly chart + top tags */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+
+              {/* Monthly bar chart — clickable bars, 4-segment */}
+              <div>
+                <Flex justify="between" align="center" className="mb-2">
+                  <Text size="1" color="gray">Activity — last 6 months</Text>
+                  <Flex gap="2" wrap="wrap">
+                    <Flex align="center" gap="1">
+                      <div className="w-2 h-2 rounded-sm" style={{ background: SEG.givenOffer }} />
+                      <Text size="1" color="gray">Given·Offer</Text>
+                    </Flex>
+                    <Flex align="center" gap="1">
+                      <div className="w-2 h-2 rounded-sm" style={{ background: SEG.givenNeed }} />
+                      <Text size="1" color="gray">Given·Need</Text>
+                    </Flex>
+                    <Flex align="center" gap="1">
+                      <div className="w-2 h-2 rounded-sm" style={{ background: SEG.takenOffer }} />
+                      <Text size="1" color="gray">Taken·Offer</Text>
+                    </Flex>
+                    <Flex align="center" gap="1">
+                      <div className="w-2 h-2 rounded-sm" style={{ background: SEG.takenNeed }} />
+                      <Text size="1" color="gray">Taken·Need</Text>
+                    </Flex>
+                  </Flex>
+                </Flex>
+                <div className="flex items-end gap-2">
+                  {monthlyData.map((m) => {
+                    const isActive = monthFilter === m.key;
+                    const goHeight = (m.givenOffer / maxMonthTotal) * 64;
+                    const gnHeight = (m.givenNeed  / maxMonthTotal) * 64;
+                    const guHeight = ((m.givenUnk) / maxMonthTotal) * 64;
+                    const toHeight = (m.takenOffer / maxMonthTotal) * 64;
+                    const tnHeight = (m.takenNeed  / maxMonthTotal) * 64;
+                    const tuHeight = ((m.takenUnk) / maxMonthTotal) * 64;
+                    return (
+                        <div
+                            key={m.key}
+                            className="flex-1 flex flex-col items-center gap-1 group relative cursor-pointer"
+                            onClick={() => setMonthFilter(isActive ? null : m.key)}
+                            title={m.total > 0 ? `${m.label}: click to filter` : m.label}
+                        >
+                          <Text size="1" color="gray" className="leading-none">{m.total > 0 ? m.total : ""}</Text>
+                          <div
+                              className="w-full flex flex-col-reverse gap-px transition-all duration-300"
+                              style={{
+                                height: "64px",
+                                opacity: monthFilter && !isActive ? 0.35 : 1,
+                                outline: isActive ? "2px solid var(--accent-9)" : "none",
+                                outlineOffset: "2px",
+                                borderRadius: "2px",
+                              }}
+                          >
+                            {guHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: guHeight,  background: "var(--orange-a6)" }} />}
+                            {gnHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: gnHeight,  background: SEG.givenNeed }} />}
+                            {goHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: goHeight,  background: SEG.givenOffer }} />}
+                            {tuHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: tuHeight,  background: "var(--blue-a6)" }} />}
+                            {tnHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: tnHeight,  background: SEG.takenNeed }} />}
+                            {toHeight  > 0 && <div className="w-full transition-all duration-500" style={{ height: toHeight,  background: SEG.takenOffer }} />}
+                          </div>
+                          <Text
+                              size="1"
+                              color="gray"
+                              className="leading-none"
+                              style={{ fontWeight: isActive ? "700" : "400", color: isActive ? "var(--accent-11)" : undefined }}
+                          >
+                            {m.label}
+                          </Text>
+                          {/* Hover tooltip */}
+                          {m.total > 0 && (
+                              <div
+                                  className="pointer-events-none absolute bottom-full mb-2 left-1/2 -translate-x-1/2 z-10
+                                         opacity-0 group-hover:opacity-100 transition-opacity duration-150
+                                         whitespace-nowrap rounded-md px-2 py-1.5 shadow-lg text-xs"
+                                  style={{ backgroundColor: "var(--gray-12)", color: "var(--gray-1)", lineHeight: 1.6 }}
+                              >
+                                {m.given > 0 && <div style={{ color: "var(--orange-a11)" }}>▲ Given: {m.given}{m.givenOffer > 0 ? ` (${m.givenOffer} offer` + (m.givenNeed > 0 ? ` · ${m.givenNeed} need` : "") + ")" : m.givenNeed > 0 ? ` (${m.givenNeed} need)` : ""}</div>}
+                                {m.taken > 0 && <div style={{ color: "var(--blue-a11)" }}>▼ Taken: {m.taken}{m.takenOffer > 0 ? ` (${m.takenOffer} offer` + (m.takenNeed > 0 ? ` · ${m.takenNeed} need` : "") + ")" : m.takenNeed > 0 ? ` (${m.takenNeed} need)` : ""}</div>}
+                              </div>
+                          )}
+                        </div>
+                    );
+                  })}
+                </div>
+                {monthFilter && (
+                    <button
+                        type="button"
+                        onClick={() => setMonthFilter(null)}
+                        className="mt-2 flex items-center gap-1 text-xs"
+                        style={{ color: "var(--accent-11)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+                    >
+                      <Cross2Icon /> Clear month filter
+                    </button>
+                )}
+              </div>
+
+              {/* Top feedback tags — badge chips */}
+              {topTags.length > 0 && (
+                  <div>
+                    <Text size="1" color="gray" className="block mb-3">Top feedback tags</Text>
+                    <Flex gap="2" wrap="wrap">
+                      {topTags.map(([tag, count]) => {
+                        const isActive = tagFilter === tag;
+                        return (
+                            <button
+                                key={tag}
+                                type="button"
+                                onClick={() => setTagFilter(isActive ? null : tag)}
+                                style={{
+                                  display: "inline-flex",
+                                  alignItems: "center",
+                                  gap: "6px",
+                                  padding: "4px 10px",
+                                  borderRadius: "var(--radius-full)",
+                                  border: "1px solid",
+                                  borderColor: isActive ? "var(--accent-9)" : "var(--gray-5)",
+                                  background: isActive ? "var(--accent-3)" : "var(--gray-a2)",
+                                  color: isActive ? "var(--accent-11)" : "var(--gray-11)",
+                                  cursor: "pointer",
+                                  fontSize: "var(--font-size-1)",
+                                  fontWeight: isActive ? "600" : "400",
+                                  transition: "all 0.15s",
+                                }}
+                            >
+                              {tag}
+                              <span style={{
+                                fontSize: "10px",
+                                opacity: 0.7,
+                                fontWeight: "500",
+                              }}>
+                              ×{count}
+                            </span>
+                            </button>
+                        );
+                      })}
+                    </Flex>
+                    {tagFilter && (
+                        <button
+                            type="button"
+                            onClick={() => setTagFilter(null)}
+                            className="mt-2 flex items-center gap-1 text-xs"
+                            style={{ color: "var(--accent-11)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+                        >
+                          <Cross2Icon /> Clear tag filter
+                        </button>
+                    )}
+                  </div>
+              )}
+            </div>
+          </Flex>
+
+          {/* ── Filter tabs + active-filter indicator ── */}
+          <Flex gap="2" wrap="wrap" align="center">
+            {([
+              { value: "all" as FilterTab,         label: "All",             count: enriched.length },
+              { value: "given" as FilterTab,        label: "Services Given",  count: stats.givenTotal },
+              { value: "taken" as FilterTab,        label: "Services Taken",  count: stats.takenTotal },
+              ...(inProgressCount > 0 ? [{ value: "in_progress" as FilterTab, label: "In Progress", count: inProgressCount }] : []),
+            ]).map((tab) => (
+              <PillButton key={tab.value} active={filter === tab.value} onClick={() => setFilter(tab.value)}>
+                {tab.label}
+                {tab.count > 0 && <span style={{ marginLeft: 6, opacity: 0.7 }}>{tab.count}</span>}
+              </PillButton>
+            ))}
+            {hasActiveFilter && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="flex items-center gap-1 text-xs px-3 py-1 rounded-full"
+                style={{
+                  background: "var(--accent-a3)",
+                  color: "var(--accent-11)",
+                  border: "1px solid var(--accent-7)",
+                  cursor: "pointer",
+                  fontSize: "var(--font-size-1)",
+                }}
+              >
+                <Cross2Icon />
+                {monthFilter && tagFilter ? "Clear filters" : monthFilter ? "Clear month" : "Clear tag"}
+              </button>
+            )}
+            {filtered.length !== enriched.length && (
+              <Text size="1" color="gray">
+                Showing {filtered.length} of {enriched.length}
+              </Text>
+            )}
+          </Flex>
+
+          {/* ── Activity list ── */}
+          {filtered.length === 0 ? (
+            <Card className="p-6 text-center">
+              <Text color="gray">No activity matches these filters</Text>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-2 gap-3">
+              {filtered.map(({ tx, userRole, rating, monthKey: _mk }) => {
+                const isProvider = userRole === "provider";
+                const counterparty = isProvider ? tx.requester : tx.provider;
+                const serviceTitle = tx.service?.title ?? rating?.service?.title ?? null;
+                const serviceId    = tx.service?.id    ?? rating?.service?.id    ?? null;
+                const date = tx.completed_at ?? tx.updated_at ?? tx.created_at;
+                const serviceType = rating?.service?.service_type;
+
+                return (
+                  <Card key={tx._id} className="p-4">
+                    <Flex direction="column" gap="3">
+                      {/* Header */}
+                      <Flex justify="between" align="start" wrap="wrap" gap="2">
+                        <Flex align="center" gap="2" wrap="wrap">
+                          {isProvider ? (
+                            <Flex align="center" gap="1">
+                              <ArrowUpIcon style={{ color: "var(--orange-10)" }} />
+                              <Text size="2" weight="bold" style={{ color: "var(--orange-11)" }}>You provided</Text>
+                            </Flex>
+                          ) : (
+                            <Flex align="center" gap="1">
+                              <ArrowDownIcon style={{ color: "var(--blue-10)" }} />
+                              <Text size="2" weight="bold" style={{ color: "var(--blue-11)" }}>You received</Text>
+                            </Flex>
+                          )}
+                          {serviceId ? (
+                            <button
+                              type="button"
+                              onClick={() => navigate(`/service/${serviceId}`)}
+                              style={{
+                                background: "none", border: "none", cursor: "pointer", padding: 0,
+                                textDecoration: "underline", textDecorationColor: "var(--gray-6)",
+                                color: "var(--gray-12)", fontSize: "var(--font-size-3)", fontWeight: "600",
+                              }}
+                            >
+                              {serviceTitle ?? "Untitled Service"}
+                            </button>
+                          ) : (
+                            <Text size="3" weight="bold">{serviceTitle ?? "Untitled Service"}</Text>
+                          )}
+
+                          {/* Counterparty + date */}
+                          <Flex align="center" gap="2" wrap="wrap">
+                            {counterparty && (
+                                <>
+                                  <Text size="1" color="gray">{isProvider ? "with" : "from"}</Text>
+                                  <button
+                                      type="button"
+                                      onClick={() => navigate(`/user/${counterparty.id}`)}
+                                      style={{
+                                        background: "none", border: "none", cursor: "pointer", padding: 0,
+                                        color: "var(--gray-11)", fontSize: "var(--font-size-1)",
+                                        textDecoration: "underline", textDecorationColor: "var(--gray-5)",
+                                      }}
+                                  >
+                                    {counterparty.full_name ?? `@${counterparty.username}`}
+                                  </button>
+                                </>
+                            )}
+                            <Text size="1" color="gray">·</Text>
+                            <Text size="1" color="gray">{formatDateShort(date)}</Text>
+                          </Flex>
+                        </Flex>
+
+                        <Flex align="center" gap="2">
+                          {serviceType && (
+                            <Badge
+                              size="1"
+                              color={serviceType === "offer" ? "blue" : "amber"}
+                              variant="soft"
+                            >
+                              {serviceType === "offer" ? "Offer" : "Need"}
+                            </Badge>
+                          )}
+                          <Badge size="1" color="gray" variant="soft">
+                            {tx.timebank_hours} hr{tx.timebank_hours !== 1 ? "s" : ""}
+                          </Badge>
+                          <StatusBadge status={tx.status} size="1" />
+                        </Flex>
+                      </Flex>
+
+                      {/* Rating */}
+                      {rating ? (
+                        <>
+                          <Separator size="4" />
+                          <Flex direction="column" gap="2">
+                            <Flex align="center" gap="2" wrap="wrap">
+                              <RatingStars value={rating.score} readonly size={14} />
+                              {rating.rater && (
+                                <Text size="1" color="gray">
+                                  from {rating.rater.full_name ?? `@${rating.rater.username}`}
+                                </Text>
+                              )}
+                            </Flex>
+                            {rating.comment && (
+                              <Text size="2" color="gray">"{rating.comment}"</Text>
+                            )}
+                            {rating.tags && rating.tags.length > 0 && (
+                              <Flex gap="1" wrap="wrap">
+                                {rating.tags.map((tag) => (
+                                  <InterestChip
+                                    key={tag}
+                                    name={tagToLabel(tag)}
+                                    selected={tagFilter === tagToLabel(tag)}
+                                    size="sm"
+                                    showIcon={false}
+                                  />
+                                ))}
+                              </Flex>
+                            )}
+                            {rating.image_urls && rating.image_urls.length > 0 && (
+                              <ImageGallery urls={rating.image_urls} alt="Feedback photo" />
+                            )}
+                          </Flex>
+                        </>
+                      ) : tx.status === "completed" ? (
+                        <Text size="1" color="gray" style={{ fontStyle: "italic" }}>No feedback yet</Text>
+                      ) : null}
+                    </Flex>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/SettingsPanel.tsx
+++ b/frontend/src/components/ui/SettingsPanel.tsx
@@ -1,0 +1,448 @@
+import { useState, useEffect } from "react";
+import {
+  Card,
+  Text,
+  Flex,
+  Button,
+  Heading,
+  Separator,
+  Switch,
+  Dialog,
+  TextField,
+} from "@radix-ui/themes";
+import { LockClosedIcon, ExitIcon } from "@radix-ui/react-icons";
+import { UserSettings, PasswordChangeForm, AccountDeletionForm } from "@/types";
+import { usersApi } from "@/services/api";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useUser } from "@/contexts/UserContext";
+import { useNavigate } from "react-router-dom";
+
+export function SettingsPanel() {
+  const navigate = useNavigate();
+  const { user, refetchUser } = useUser();
+
+  const [settings, setSettings] = useState<UserSettings>({
+    profile_visible: true,
+    show_email: false,
+    show_location: true,
+    email_notifications: true,
+    service_matches_notifications: true,
+    messages_notifications: true,
+  });
+  const [settingsLoading, setSettingsLoading] = useState(false);
+
+  const [showPasswordDialog, setShowPasswordDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [passwordForm, setPasswordForm] = useState<PasswordChangeForm>({
+    current_password: "",
+    new_password: "",
+    confirm_password: "",
+  });
+  const [deleteForm, setDeleteForm] = useState<AccountDeletionForm>({
+    password: "",
+  });
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    setSettings({
+      profile_visible: user.profile_visible ?? true,
+      show_email: user.show_email ?? false,
+      show_location: user.show_location ?? true,
+      email_notifications: user.email_notifications ?? true,
+      service_matches_notifications:
+        user.service_matches_notifications ?? true,
+      messages_notifications: user.messages_notifications ?? true,
+    });
+  }, [user]);
+
+  const handleSettingsChange = async (
+    field: keyof UserSettings,
+    value: boolean,
+  ) => {
+    const oldSettings = { ...settings };
+    const newSettings = { ...settings, [field]: value };
+    setSettings(newSettings);
+    setSettingsLoading(true);
+    try {
+      const response = await usersApi.updateSettings({ [field]: value });
+      refetchUser();
+      setSettings({
+        profile_visible: response.data.profile_visible ?? true,
+        show_email: response.data.show_email ?? false,
+        show_location: response.data.show_location ?? true,
+        email_notifications: response.data.email_notifications ?? true,
+        service_matches_notifications:
+          response.data.service_matches_notifications ?? true,
+        messages_notifications: response.data.messages_notifications ?? true,
+      });
+    } catch (error) {
+      console.error("Error updating settings:", error);
+      setSettings(oldSettings);
+      alert("Failed to update settings. Please try again.");
+    } finally {
+      setSettingsLoading(false);
+    }
+  };
+
+  const handlePasswordChange = async () => {
+    if (passwordForm.new_password !== passwordForm.confirm_password) {
+      alert("New passwords do not match");
+      return;
+    }
+    if (passwordForm.new_password.length < 8) {
+      alert("Password must be at least 8 characters long");
+      return;
+    }
+    setPasswordLoading(true);
+    try {
+      await usersApi.changePassword(passwordForm);
+      setShowPasswordDialog(false);
+      setPasswordForm({
+        current_password: "",
+        new_password: "",
+        confirm_password: "",
+      });
+    } catch (error: any) {
+      console.error("Error changing password:", error);
+      alert(
+        error.response?.data?.detail ||
+          "Failed to change password. Please check your current password.",
+      );
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!deleteForm.password) {
+      alert("Please enter your password to confirm account deletion");
+      return;
+    }
+    setDeleteConfirmOpen(true);
+  };
+
+  const handleConfirmDeleteAccount = async () => {
+    setDeleteLoading(true);
+    try {
+      await usersApi.deleteAccount(deleteForm);
+      localStorage.removeItem("access_token");
+      window.location.href = "/";
+    } catch (error: any) {
+      console.error("Error deleting account:", error);
+      alert(
+        error.response?.data?.detail ||
+          "Failed to delete account. Please check your password.",
+      );
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const handleConfirmLogout = () => {
+    localStorage.removeItem("access_token");
+    navigate("/");
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <div className="space-y-6">
+        <div>
+          <Heading size="4" mb="3">
+            Privacy
+          </Heading>
+          <div className="space-y-3">
+            <Flex justify="between" align="center">
+              <div className="grid gap-1">
+                <Text size="2" weight="bold">
+                  Show Email
+                </Text>
+                <Text size="1" color="gray">
+                  Display your email on your profile
+                </Text>
+              </div>
+              <Switch
+                  checked={settings.show_email}
+                  onCheckedChange={(checked) =>
+                      handleSettingsChange("show_email", checked)
+                  }
+                  disabled={settingsLoading}
+              />
+            </Flex>
+            <Flex justify="between" align="center">
+              <div className="grid gap-1">
+                <Text size="2" weight="bold">
+                  Show Location
+                </Text>
+                <Text size="1" color="gray">
+                  Display your location on your profile
+                </Text>
+              </div>
+              <Switch
+                  checked={settings.show_location}
+                  onCheckedChange={(checked) =>
+                      handleSettingsChange("show_location", checked)
+                  }
+                  disabled={settingsLoading}
+              />
+            </Flex>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div>
+          <Heading size="4" mb="3">
+            Notifications
+          </Heading>
+          <div className="space-y-3">
+            <Flex justify="between" align="center">
+              <div className="grid gap-1">
+                <Text size="2" weight="bold">
+                  Email Notifications
+                </Text>
+                <Text size="1" color="gray">
+                  Receive notifications via email
+                </Text>
+              </div>
+              <Switch
+                  checked={settings.email_notifications}
+                  onCheckedChange={(checked) =>
+                      handleSettingsChange("email_notifications", checked)
+                  }
+                  disabled={settingsLoading}
+              />
+            </Flex>
+            <Flex justify="between" align="center">
+              <div className="grid gap-1">
+                <Text size="2" weight="bold">
+                  Service Matches
+                </Text>
+                <Text size="1" color="gray">
+                  Get notified when services match your needs
+                </Text>
+              </div>
+              <Switch
+                  checked={settings.service_matches_notifications}
+                  onCheckedChange={(checked) =>
+                      handleSettingsChange(
+                          "service_matches_notifications",
+                          checked,
+                      )
+                  }
+                  disabled={settingsLoading}
+              />
+            </Flex>
+            <Flex justify="between" align="center">
+              <div className="grid gap-1">
+                <Text size="2" weight="bold">
+                  Messages
+                </Text>
+                <Text size="1" color="gray">
+                  Get notified about new messages
+                </Text>
+              </div>
+              <Switch
+                  checked={settings.messages_notifications}
+                  onCheckedChange={(checked) =>
+                      handleSettingsChange("messages_notifications", checked)
+                  }
+                  disabled={settingsLoading}
+              />
+            </Flex>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div>
+          <Heading size="4" mb="3">
+            Account
+          </Heading>
+          <div className="space-y-3">
+            <Button
+                variant="soft"
+                size="2"
+                className="w-full justify-start"
+                onClick={() => setShowPasswordDialog(true)}
+            >
+              <LockClosedIcon className="w-4 h-4 mr-2" />
+              Change Password
+            </Button>
+            <Button
+                variant="soft"
+                size="2"
+                className="w-full justify-start"
+                onClick={() => setLogoutConfirmOpen(true)}
+            >
+              <ExitIcon className="w-4 h-4 mr-2" />
+              Logout
+            </Button>
+            <Button
+                variant="soft"
+                color="red"
+                size="2"
+                className="w-full justify-start"
+                onClick={() => setShowDeleteDialog(true)}
+            >
+              Delete Account
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Dialog.Root
+        open={showPasswordDialog}
+        onOpenChange={setShowPasswordDialog}
+      >
+        <Dialog.Content className="max-w-md">
+          <Dialog.Title>Change Password</Dialog.Title>
+          <Dialog.Description className="mb-4">
+            Enter your current password and choose a new one.
+          </Dialog.Description>
+
+          <div className="space-y-4">
+            <div>
+              <Text size="2" weight="bold" className="block mb-1">
+                Current Password
+              </Text>
+              <TextField.Root
+                type="password"
+                value={passwordForm.current_password}
+                onChange={(e) =>
+                  setPasswordForm({
+                    ...passwordForm,
+                    current_password: e.target.value,
+                  })
+                }
+                placeholder="Enter current password"
+                size="2"
+              />
+            </div>
+            <div>
+              <Text size="2" weight="bold" className="block mb-1">
+                New Password
+              </Text>
+              <TextField.Root
+                type="password"
+                value={passwordForm.new_password}
+                onChange={(e) =>
+                  setPasswordForm({
+                    ...passwordForm,
+                    new_password: e.target.value,
+                  })
+                }
+                placeholder="Enter new password"
+                size="2"
+              />
+            </div>
+            <div>
+              <Text size="2" weight="bold" className="block mb-1">
+                Confirm New Password
+              </Text>
+              <TextField.Root
+                type="password"
+                value={passwordForm.confirm_password}
+                onChange={(e) =>
+                  setPasswordForm({
+                    ...passwordForm,
+                    confirm_password: e.target.value,
+                  })
+                }
+                placeholder="Confirm new password"
+                size="2"
+              />
+            </div>
+          </div>
+
+          <Flex gap="3" mt="4" justify="end">
+            <Button
+              variant="soft"
+              onClick={() => {
+                setShowPasswordDialog(false);
+                setPasswordForm({
+                  current_password: "",
+                  new_password: "",
+                  confirm_password: "",
+                });
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handlePasswordChange} disabled={passwordLoading}>
+              {passwordLoading ? "Changing..." : "Change Password"}
+            </Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <Dialog.Root open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <Dialog.Content className="max-w-md">
+          <Dialog.Title color="red">Delete Account</Dialog.Title>
+          <Dialog.Description className="mb-4">
+            This action cannot be undone. This will permanently delete your
+            account and all associated data.
+          </Dialog.Description>
+
+          <div className="space-y-4">
+            <div>
+              <Text size="2" weight="bold" className="block mb-1">
+                Enter your password to confirm
+              </Text>
+              <TextField.Root
+                type="password"
+                value={deleteForm.password}
+                onChange={(e) =>
+                  setDeleteForm({ ...deleteForm, password: e.target.value })
+                }
+                placeholder="Enter your password"
+                size="2"
+              />
+            </div>
+          </div>
+
+          <Flex gap="3" mt="4" justify="end">
+            <Button
+              variant="soft"
+              onClick={() => {
+                setShowDeleteDialog(false);
+                setDeleteForm({ password: "" });
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={handleDeleteAccount}
+              disabled={deleteLoading}
+            >
+              {deleteLoading ? "Deleting..." : "Delete Account"}
+            </Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        title="Delete your account?"
+        description="Are you sure you want to delete your account? This action cannot be undone."
+        confirmLabel="Delete account"
+        variant="danger"
+        onConfirm={handleConfirmDeleteAccount}
+      />
+      <ConfirmDialog
+        open={logoutConfirmOpen}
+        onOpenChange={setLogoutConfirmOpen}
+        title="Log out?"
+        description="Are you sure you want to logout?"
+        confirmLabel="Log out"
+        onConfirm={handleConfirmLogout}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/ui/SettingsPanel.tsx
+++ b/frontend/src/components/ui/SettingsPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import {
-  Card,
   Text,
   Flex,
   Button,

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -25,6 +25,7 @@ import type { Report, ReportStatus } from "@/types";
 import { TextField } from "@radix-ui/themes";
 import { useUser } from "@/contexts/UserContext";
 import { InterestChip } from "@/components/ui/InterestChip";
+import { SettingsPanel } from "@/components/ui/SettingsPanel";
 import { useNavigate } from "react-router-dom";
 
 export function AdminPanel() {
@@ -361,6 +362,9 @@ export function AdminPanel() {
           </Tabs.Trigger>
           <Tabs.Trigger value="reports">
             Reports ({reportsData?.total || 0})
+          </Tabs.Trigger>
+          <Tabs.Trigger value="settings">
+            My Settings
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -897,6 +901,12 @@ export function AdminPanel() {
               </Table.Root>
             )}
           </Card>
+        </Tabs.Content>
+
+        <Tabs.Content value="settings" className="mt-6">
+          <div className="max-w-xl">
+            <SettingsPanel />
+          </div>
         </Tabs.Content>
       </Tabs.Root>
 

--- a/frontend/src/pages/CommunityDetail.tsx
+++ b/frontend/src/pages/CommunityDetail.tsx
@@ -7,9 +7,9 @@ import {
 import { Form } from "radix-ui";
 import {
   ArrowLeftIcon, PlusIcon, Pencil1Icon,
-  TrashIcon, ChevronUpIcon,
+  TrashIcon, ChevronUpIcon, GlobeIcon,
 } from "@radix-ui/react-icons";
-import { MessageCircleIcon, UsersIcon, PinIcon } from "lucide-react";
+import { MessageCircleIcon, UsersIcon, PinIcon, CalendarClockIcon } from "lucide-react";
 import { communityApi, getImageUrl, uploadApi } from "@/services/api";
 import { useUser } from "@/App";
 import { Community, CommunityMember, CommunityPost, TagEntity, ForumEvent, ForumDiscussion } from "@/types";

--- a/frontend/src/pages/MyServices.tsx
+++ b/frontend/src/pages/MyServices.tsx
@@ -385,7 +385,6 @@ export function MyServices({
         <div className="mb-8 grid">
           <MyServicesTab
             services={services}
-            takenServices={applicationServices}
             serviceTransactions={serviceTransactions}
             currentUserId={currentUserId}
             requiresNeedCreation={timebankData?.requires_need_creation ?? false}

--- a/frontend/src/pages/MyServicesTab.tsx
+++ b/frontend/src/pages/MyServicesTab.tsx
@@ -19,10 +19,10 @@ import {
 } from "@/components/ui/ConfirmCompletionModal";
 import { InterestChip } from "@/components/ui/InterestChip";
 import { EditServiceDialog } from "@/components/forms/EditServiceDialog";
-import { ServicesSummaryCard } from "@/components/ui/ServicesSummaryCard";
 import { ratingsApi } from "@/services/api";
 import { ImageGallery } from "@/components/ui/ImageGallery";
 import {
+  MagnifyingGlassIcon,
   ClockIcon,
   CheckCircledIcon,
   ArrowRightIcon,
@@ -35,7 +35,6 @@ import { useNavigate } from "react-router-dom";
 
 interface MyServicesTabProps {
   services: Service[];
-  takenServices?: Service[];
   serviceTransactions: Record<string, Transaction[]>;
   currentUserId: string | null;
   requiresNeedCreation?: boolean;
@@ -65,7 +64,6 @@ interface MyServicesTabProps {
 
 export function MyServicesTab({
   services,
-  takenServices,
   serviceTransactions,
   currentUserId,
   requiresNeedCreation = false,
@@ -230,12 +228,16 @@ export function MyServicesTab({
 
   return (
     <div className="space-y-6">
-      <ServicesSummaryCard
-        services={services}
-        takenServices={takenServices}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-      />
+      <div className="relative">
+        <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--gray-9)] w-4 h-4 pointer-events-none" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search services by title, description or tag..."
+          className="w-full pl-9 pr-4 py-2 text-sm rounded-lg border border-[var(--gray-a5)] bg-[var(--gray-a2)] placeholder-[var(--gray-9)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-8)]"
+        />
+      </div>
       <div className="flex flex-row gap-2">
         <Button
           variant={!statusFilter ? "solid" : "soft"}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -48,6 +48,7 @@ import {
   UserIcon,
   LucideBriefcase,
   LucideMessageCircle,
+  ActivityIcon,
 } from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -100,6 +101,7 @@ export function Profile() {
     "timebank",
     "saved",
     "chat",
+    "activity",
   ] as const;
   const profileTab = allowedTabs.includes(profileTabFromUrl as any)
     ? profileTabFromUrl
@@ -345,6 +347,10 @@ export function Profile() {
           <Tabs.Trigger value="profile">
             <UserIcon className="w-4 h-4 mr-2" />
             Profile
+          </Tabs.Trigger>
+          <Tabs.Trigger value="activity">
+            <ActivityIcon className="w-4 h-4 mr-2" />
+            Activity
           </Tabs.Trigger>
           <Tabs.Trigger value="services">
             <LucideBriefcase className="w-4 h-4 mr-2" />
@@ -1023,13 +1029,6 @@ export function Profile() {
               </Box>
 
               <BadgeDisplay />
-
-              <ActivitySummarySection
-                transactions={myTransactionsData?.transactions ?? []}
-                ratings={detailedRatings}
-                currentUserId={user._id}
-                isLoading={detailedRatingsLoading || transactionsLoading}
-              />
             </div>
           </Tabs.Content>
 
@@ -1072,6 +1071,17 @@ export function Profile() {
 
           <Tabs.Content value="chat">
             {visitedTabs.has("chat") && <Chat />}
+          </Tabs.Content>
+
+          <Tabs.Content value="activity">
+            {visitedTabs.has("activity") && (
+              <ActivitySummarySection
+                transactions={myTransactionsData?.transactions ?? []}
+                ratings={detailedRatings}
+                currentUserId={user._id}
+                isLoading={detailedRatingsLoading || transactionsLoading}
+              />
+            )}
           </Tabs.Content>
         </Box>
       </Tabs.Root>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -33,8 +33,8 @@ import {
   RatingDetailed,
   TimeBankResponse,
 } from "@/types";
-import { usersApi, ratingsApi, uploadApi, getImageUrl, servicesApi, joinRequestsApi } from "@/services/api";
-import { ReviewCard } from "@/components/ui/ReviewCard";
+import { usersApi, ratingsApi, uploadApi, getImageUrl, servicesApi, joinRequestsApi, transactionsApi } from "@/services/api";
+import { ActivitySummarySection } from "@/components/ui/ActivitySummarySection";
 import { useUser } from "@/contexts/UserContext";
 import { MyServices } from "./MyServices";
 import { BadgeDisplay } from "@/components/ui/BadgeDisplay";
@@ -255,6 +255,13 @@ export function Profile() {
         requests: requestsRes.data.total ?? 0,
       };
     },
+    enabled: !!user?._id,
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const { data: myTransactionsData, isLoading: transactionsLoading } = useQuery({
+    queryKey: ["my-transactions-activity", user?._id],
+    queryFn: () => transactionsApi.getMyTransactions(1, 100).then((r) => r.data),
     enabled: !!user?._id,
     staleTime: 2 * 60 * 1000,
   });
@@ -1339,64 +1346,12 @@ export function Profile() {
               </Grid>
               <BadgeDisplay />
 
-              {/* Reviews Section */}
-              <div className="space-y-6">
-                <Heading size="5">Reviews Received</Heading>
-                {detailedRatingsLoading ? (
-                  <Card className="p-6 text-center">
-                    <Text color="gray">Loading reviews...</Text>
-                  </Card>
-                ) : detailedRatings.length === 0 ? (
-                  <Card className="p-6 text-center">
-                    <Text color="gray">No reviews received yet</Text>
-                  </Card>
-                ) : (
-                  <>
-                    {(() => {
-                      const providerRatings = detailedRatings.filter(
-                        (r) => r.transaction?.rated_user_role === "provider"
-                      );
-                      const takerRatings = detailedRatings.filter(
-                        (r) => r.transaction?.rated_user_role === "taker"
-                      );
-                      const unknownRatings = detailedRatings.filter(
-                        (r) => !r.transaction?.rated_user_role
-                      );
-                      return (
-                        <>
-                          {providerRatings.length > 0 && (
-                            <div className="space-y-3">
-                              <Heading size="3" color="gray">As Service Provider</Heading>
-                              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                                {providerRatings.map((rating) => (
-                                  <ReviewCard key={rating._id} rating={rating} />
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                          {takerRatings.length > 0 && (
-                            <div className="space-y-3">
-                              <Heading size="3" color="gray">As Service Taker</Heading>
-                              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                                {takerRatings.map((rating) => (
-                                  <ReviewCard key={rating._id} rating={rating} />
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                          {unknownRatings.length > 0 && (
-                            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                              {unknownRatings.map((rating) => (
-                                <ReviewCard key={rating._id} rating={rating} />
-                              ))}
-                            </div>
-                          )}
-                        </>
-                      );
-                    })()}
-                  </>
-                )}
-              </div>
+              <ActivitySummarySection
+                transactions={myTransactionsData?.transactions ?? []}
+                ratings={detailedRatings}
+                currentUserId={user._id}
+                isLoading={detailedRatingsLoading || transactionsLoading}
+              />
             </div>
           </Tabs.Content>
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -7,28 +7,20 @@ import {
   Badge,
   Button,
   Heading,
-  Separator,
   Box,
   TextField,
   TextArea,
-  Switch,
-  Dialog,
   Grid,
   Tabs,
 } from "@radix-ui/themes";
 import {
   CheckCircledIcon,
   Crosshair1Icon,
-  LockClosedIcon,
   Pencil1Icon,
   CheckIcon,
   Cross2Icon,
-  ExitIcon,
 } from "@radix-ui/react-icons";
 import {
-  UserSettings,
-  PasswordChangeForm,
-  AccountDeletionForm,
   SocialLinks,
   RatingDetailed,
   TimeBankResponse,
@@ -42,7 +34,6 @@ import { RatingStars } from "@/components/ui/RatingStars";
 import { InterestSelector } from "@/components/ui/InterestSelector";
 import { InterestChip } from "@/components/ui/InterestChip";
 import { MapLocationPicker } from "@/components/ui/MapLocationPicker";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { PROFILE_PICTURE_PRESETS } from "@/constants/profilePicturePresets";
 import {
   Linkedin,
@@ -83,31 +74,10 @@ export function Profile() {
     interests: [] as string[],
   });
   const [showInterestSelector, setShowInterestSelector] = useState(false);
-  const [settings, setSettings] = useState<UserSettings>({
-    profile_visible: true,
-    show_email: false,
-    show_location: true,
-    email_notifications: true,
-    service_matches_notifications: true,
-    messages_notifications: true,
-  });
-  const [showPasswordDialog, setShowPasswordDialog] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [profilePictureUploading, setProfilePictureUploading] = useState(false);
   const [profilePictureError, setProfilePictureError] = useState<string | null>(
     null,
   );
-  const [passwordForm, setPasswordForm] = useState<PasswordChangeForm>({
-    current_password: "",
-    new_password: "",
-    confirm_password: "",
-  });
-  const [deleteForm, setDeleteForm] = useState<AccountDeletionForm>({
-    password: "",
-  });
-  const [settingsLoading, setSettingsLoading] = useState(false);
-  const [passwordLoading, setPasswordLoading] = useState(false);
-  const [deleteLoading, setDeleteLoading] = useState(false);
   const [myservicesCounts, setMyservicesCounts] = useState({
     services: 0,
     applications: 0,
@@ -199,14 +169,6 @@ export function Profile() {
         portfolio: user.social_links?.portfolio || "",
       },
       interests: user.interests || [],
-    });
-    setSettings({
-      profile_visible: user.profile_visible ?? true,
-      show_email: user.show_email ?? false,
-      show_location: user.show_location ?? true,
-      email_notifications: user.email_notifications ?? true,
-      service_matches_notifications: user.service_matches_notifications ?? true,
-      messages_notifications: user.messages_notifications ?? true,
     });
   }, [user]);
 
@@ -359,108 +321,6 @@ export function Profile() {
     });
   };
 
-  const handleSettingsChange = async (
-    field: keyof UserSettings,
-    value: boolean,
-  ) => {
-    const oldSettings = { ...settings };
-    const newSettings = { ...settings, [field]: value };
-    setSettings(newSettings);
-    setSettingsLoading(true);
-
-    try {
-      const response = await usersApi.updateSettings({ [field]: value });
-      refetchUser();
-      // Update settings from response
-      setSettings({
-        profile_visible: response.data.profile_visible ?? true,
-        show_email: response.data.show_email ?? false,
-        show_location: response.data.show_location ?? true,
-        email_notifications: response.data.email_notifications ?? true,
-        service_matches_notifications:
-          response.data.service_matches_notifications ?? true,
-        messages_notifications: response.data.messages_notifications ?? true,
-      });
-    } catch (error) {
-      console.error("Error updating settings:", error);
-      // Revert on error
-      setSettings(oldSettings);
-      alert("Failed to update settings. Please try again.");
-    } finally {
-      setSettingsLoading(false);
-    }
-  };
-
-  const handlePasswordChange = async () => {
-    if (passwordForm.new_password !== passwordForm.confirm_password) {
-      alert("New passwords do not match");
-      return;
-    }
-
-    if (passwordForm.new_password.length < 8) {
-      alert("Password must be at least 8 characters long");
-      return;
-    }
-
-    setPasswordLoading(true);
-    try {
-      await usersApi.changePassword(passwordForm);
-      // alert("Password changed successfully");
-      setShowPasswordDialog(false);
-      setPasswordForm({
-        current_password: "",
-        new_password: "",
-        confirm_password: "",
-      });
-    } catch (error: any) {
-      console.error("Error changing password:", error);
-      alert(
-        error.response?.data?.detail ||
-          "Failed to change password. Please check your current password.",
-      );
-    } finally {
-      setPasswordLoading(false);
-    }
-  };
-
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
-
-  const handleDeleteAccount = async () => {
-    if (!deleteForm.password) {
-      alert("Please enter your password to confirm account deletion");
-      return;
-    }
-    setDeleteConfirmOpen(true);
-  };
-
-  const handleConfirmDeleteAccount = async () => {
-    setDeleteLoading(true);
-    try {
-      await usersApi.deleteAccount(deleteForm);
-      // alert("Account deleted successfully");
-      localStorage.removeItem("access_token");
-      window.location.href = "/";
-    } catch (error: any) {
-      console.error("Error deleting account:", error);
-      alert(
-        error.response?.data?.detail ||
-          "Failed to delete account. Please check your password.",
-      );
-    } finally {
-      setDeleteLoading(false);
-    }
-  };
-
-  const handleLogout = () => {
-    setLogoutConfirmOpen(true);
-  };
-
-  const handleConfirmLogout = () => {
-    localStorage.removeItem("access_token");
-    navigate("/");
-    window.location.reload();
-  };
 
   if (isLoading) {
     return (
@@ -557,27 +417,26 @@ export function Profile() {
           {/* ── Profile Tab ── */}
           <Tabs.Content value="profile">
             <div className="grid gap-6">
-              <Grid columns={{ initial: "1", md: "2" }} gap="6">
-                {/* Profile Information */}
-                <Box>
-                  <Card size="4" className="p-6">
-                    <Flex
+              {/* Profile Information */}
+              <Box>
+                <Card size="4" className="p-6">
+                  <Flex
                       align="center"
                       justify="between"
                       className="col-span-2 mb-4"
-                    >
-                      <Heading size="5">Profile Information</Heading>
-                      {!isEditing ? (
+                  >
+                    <Heading size="5">Profile Information</Heading>
+                    {!isEditing ? (
                         <Button onClick={handleEdit} size="2">
                           <Pencil1Icon className="w-4 h-4 mr-2" />
                           Edit Profile
                         </Button>
-                      ) : (
+                    ) : (
                         <Flex gap="2">
                           <Button
-                            onClick={handleCancel}
-                            variant="soft"
-                            size="2"
+                              onClick={handleCancel}
+                              variant="soft"
+                              size="2"
                           >
                             <Cross2Icon className="w-4 h-4 mr-2" />
                             Cancel
@@ -587,114 +446,116 @@ export function Profile() {
                             Save Changes
                           </Button>
                         </Flex>
-                      )}
-                    </Flex>
+                    )}
+                  </Flex>
 
-                    <div className="space-y-4">
-                      {/* Avatar and Basic Info */}
-                      <Flex align="center" gap="4">
-                        <Avatar
-                          src={
-                            isEditing
+                  {/* Avatar and Basic Info */}
+                  <Flex align="center" gap="4">
+                    <Avatar
+                        src={
+                          isEditing
                               ? getImageUrl(editForm.profile_picture) ||
-                                undefined
+                              undefined
                               : getImageUrl(user.profile_picture) || undefined
-                          }
-                          fallback={user.full_name?.[0] || user.username[0]}
-                          size="6"
-                        />
-                        <div className="flex-1">
-                          <Flex align="center" gap="2" mb="1">
-                            <Heading size="4">
-                              {isEditing ? (
-                                <TextField.Root
+                        }
+                        fallback={user.full_name?.[0] || user.username[0]}
+                        size="6"
+                    />
+                    <div className="flex-1">
+                      <Flex align="center" gap="2" mb="1">
+                        <Heading size="4">
+                          {isEditing ? (
+                              <TextField.Root
                                   value={editForm.full_name}
                                   onChange={(e) =>
-                                    handleInputChange(
-                                      "full_name",
-                                      e.target.value,
-                                    )
+                                      handleInputChange(
+                                          "full_name",
+                                          e.target.value,
+                                      )
                                   }
                                   placeholder="Full Name"
                                   size="2"
-                                />
-                              ) : (
-                                user.full_name || user.username
-                              )}
-                            </Heading>
-                            {user.is_verified && (
-                              <CheckCircledIcon className="w-4 h-4 text-green-600" />
-                            )}
-                          </Flex>
-                          <Text size="3" color="gray">
-                            @{user.username}
-                          </Text>
-                          {user.is_verified && (
-                            <Badge
+                              />
+                          ) : (
+                              user.full_name || user.username
+                          )}
+                        </Heading>
+                        {user.is_verified && (
+                            <CheckCircledIcon className="w-4 h-4 text-green-600" />
+                        )}
+                      </Flex>
+                      <Text size="3" color="gray">
+                        @{user.username}
+                      </Text>
+                      {user.is_verified && (
+                          <Badge
                               color="green"
                               variant="soft"
                               size="1"
                               className="ml-2"
-                            >
-                              Verified User
-                            </Badge>
-                          )}
-                        </div>
-                      </Flex>
+                          >
+                            Verified User
+                          </Badge>
+                      )}
+                    </div>
+                  </Flex>
 
-                      {/* Profile Picture: presets, upload, or URL */}
-                      {isEditing && (
-                        <div className="space-y-2">
-                          <Text size="2" weight="bold" className="block">
-                            Profile Picture
+
+
+
+                  {/* Profile Picture: presets, upload, or URL */}
+                  {isEditing && (
+                      <div className="space-y-2">
+                        <Text size="2" weight="bold" className="block">
+                          Profile Picture
+                        </Text>
+
+                        {/* Preset avatars */}
+                        <div>
+                          <Text size="1" color="gray" className="block mb-2">
+                            Choose a preset avatar
                           </Text>
-
-                          {/* Preset avatars */}
-                          <div>
-                            <Text size="1" color="gray" className="block mb-2">
-                              Choose a preset avatar
-                            </Text>
-                            <Grid columns="6" gap="2" className="max-w-md">
-                              {PROFILE_PICTURE_PRESETS.map((preset) => {
-                                const isSelected =
+                          <Grid columns="6" gap="2" className="max-w-md">
+                            {PROFILE_PICTURE_PRESETS.map((preset) => {
+                              const isSelected =
                                   editForm.profile_picture === preset.url;
-                                return (
+                              return (
                                   <button
-                                    key={preset.id}
-                                    type="button"
-                                    onClick={() => {
-                                      handleInputChange(
-                                        "profile_picture",
-                                        preset.url,
-                                      );
-                                      setProfilePictureError(null);
-                                    }}
-                                    className={`rounded-full p-0.5 transition-all focus:outline-none focus:ring-2 focus:ring-cyan-9 ${
-                                      isSelected
-                                        ? "ring-2 ring-cyan-9 ring-offset-2 ring-offset-gray-1 dark:ring-offset-gray-2"
-                                        : "hover:opacity-90"
-                                    }`}
-                                    title={preset.name}
+                                      key={preset.id}
+                                      type="button"
+                                      onClick={() => {
+                                        handleInputChange(
+                                            "profile_picture",
+                                            preset.url,
+                                        );
+                                        setProfilePictureError(null);
+                                      }}
+                                      className={`rounded-full p-0.5 transition-all focus:outline-none focus:ring-2 focus:ring-cyan-9 ${
+                                          isSelected
+                                              ? "ring-2 ring-cyan-9 ring-offset-2 ring-offset-gray-1 dark:ring-offset-gray-2"
+                                              : "hover:opacity-90"
+                                      }`}
+                                      title={preset.name}
                                   >
                                     <Avatar
-                                      src={preset.url}
-                                      fallback={preset.name[0]}
-                                      size="3"
-                                      radius="full"
-                                      className="w-full aspect-square"
+                                        src={preset.url}
+                                        fallback={preset.name[0]}
+                                        size="3"
+                                        radius="full"
+                                        className="w-full aspect-square"
                                     />
                                   </button>
-                                );
-                              })}
-                            </Grid>
-                          </div>
+                              );
+                            })}
+                          </Grid>
+                        </div>
 
-                          <Text size="1" color="gray" className="block mt-6">
-                            Or upload your own:
-                          </Text>
-                          <Flex gap="2" align="center" wrap="wrap">
-                            <label className="cursor-pointer">
-                              <input
+                        <Text size="1" color="gray" className="block mt-6">
+                          Or upload your own:
+                        </Text>
+                        <Flex gap="2" align="center" wrap="wrap">
+                          <label className="cursor-pointer">
+                            <input
                                 type="file"
                                 accept="image/jpeg,image/png,image/webp"
                                 className="sr-only"
@@ -705,7 +566,7 @@ export function Profile() {
                                   const maxMb = 5;
                                   if (file.size > maxMb * 1024 * 1024) {
                                     setProfilePictureError(
-                                      `File must be under ${maxMb} MB`,
+                                        `File must be under ${maxMb} MB`,
                                     );
                                     return;
                                   }
@@ -713,16 +574,16 @@ export function Profile() {
                                   setProfilePictureUploading(true);
                                   try {
                                     const res =
-                                      await uploadApi.uploadProfilePicture(
-                                        file,
-                                      );
+                                        await uploadApi.uploadProfilePicture(
+                                            file,
+                                        );
                                     handleInputChange(
-                                      "profile_picture",
-                                      res.data.url,
+                                        "profile_picture",
+                                        res.data.url,
                                     );
                                   } catch (err: any) {
                                     setProfilePictureError(
-                                      err.response?.data?.detail ||
+                                        err.response?.data?.detail ||
                                         "Upload failed",
                                     );
                                   } finally {
@@ -730,620 +591,437 @@ export function Profile() {
                                     e.target.value = "";
                                   }
                                 }}
-                              />
-                              <Button
+                            />
+                            <Button
                                 type="button"
                                 size="2"
                                 variant="soft"
                                 asChild
-                              >
+                            >
                                 <span>
                                   {profilePictureUploading
-                                    ? "Uploading..."
-                                    : "Upload photo"}
+                                      ? "Uploading..."
+                                      : "Upload photo"}
                                 </span>
-                              </Button>
-                            </label>
-                            <Text size="2" color="gray">
-                              or paste URL:
-                            </Text>
-                          </Flex>
-                          <TextField.Root
+                            </Button>
+                          </label>
+                          <Text size="2" color="gray">
+                            or paste URL:
+                          </Text>
+                        </Flex>
+                        <TextField.Root
                             value={editForm.profile_picture}
                             onChange={(e) => {
                               handleInputChange(
-                                "profile_picture",
-                                e.target.value,
+                                  "profile_picture",
+                                  e.target.value,
                               );
                               setProfilePictureError(null);
                             }}
                             placeholder="https://example.com/photo.jpg or /uploads/..."
                             size="2"
-                          />
-                          {profilePictureError && (
+                        />
+                        {profilePictureError && (
                             <Text size="2" color="red">
                               {profilePictureError}
                             </Text>
-                          )}
-                        </div>
-                      )}
+                        )}
+                      </div>
+                  )}
 
-                      {/* Email */}
-                      <div>
-                        <Text size="2" weight="bold" mr="2">
-                          Email
-                        </Text>
-                        {isEditing ? (
+
+                  <div className="grid grid-cols-2 gap-3">
+                    {/* Email */}
+                    <div>
+                      <Text size="2" weight="bold" mr="2">
+                        Email
+                      </Text>
+                      {isEditing ? (
                           <TextField.Root
-                            value={editForm.email}
-                            onChange={(e) =>
-                              handleInputChange("email", e.target.value)
-                            }
-                            placeholder="Email"
-                            size="2"
+                              value={editForm.email}
+                              onChange={(e) =>
+                                  handleInputChange("email", e.target.value)
+                              }
+                              placeholder="Email"
+                              size="2"
                           />
-                        ) : (
+                      ) : (
                           <Text size="2">{user.email}</Text>
-                        )}
-                      </div>
+                      )}
+                    </div>
 
-                      {/* Bio */}
-                      <div>
-                        <Text size="2" weight="bold" mr="2">
-                          Bio
-                        </Text>
-                        {isEditing ? (
+                    {/* Bio */}
+                    <div>
+                      <Text size="2" weight="bold" mr="2">
+                        Bio
+                      </Text>
+                      {isEditing ? (
                           <TextArea
-                            value={editForm.bio}
-                            onChange={(e) =>
-                              handleInputChange("bio", e.target.value)
-                            }
-                            placeholder="Tell us about yourself..."
-                            size="2"
-                            rows={3}
+                              value={editForm.bio}
+                              onChange={(e) =>
+                                  handleInputChange("bio", e.target.value)
+                              }
+                              placeholder="Tell us about yourself..."
+                              size="2"
+                              rows={3}
                           />
-                        ) : (
+                      ) : (
                           <Text size="2">{user.bio || "No bio provided"}</Text>
-                        )}
-                      </div>
+                      )}
+                    </div>
 
-                      {/* Location */}
-                      <div>
-                        <Text size="2" weight="bold" mr="2">
-                          Location
-                        </Text>
-                        {isEditing ? (
+                    {/* Location */}
+                    <div>
+                      <Text size="2" weight="bold" mr="2">
+                        Location
+                      </Text>
+                      {isEditing ? (
                           <MapLocationPicker
-                            value={editForm.location}
-                            onChange={(loc) =>
-                              setEditForm((prev) => ({
-                                ...prev,
-                                location: {
-                                  latitude: loc.latitude,
-                                  longitude: loc.longitude,
-                                  address: loc.address || "",
-                                },
-                              }))
-                            }
-                            height={180}
-                            markerColor="#2563eb"
+                              value={editForm.location}
+                              onChange={(loc) =>
+                                  setEditForm((prev) => ({
+                                    ...prev,
+                                    location: {
+                                      latitude: loc.latitude,
+                                      longitude: loc.longitude,
+                                      address: loc.address || "",
+                                    },
+                                  }))
+                              }
+                              height={180}
+                              markerColor="#2563eb"
                           />
-                        ) : (
+                      ) : (
                           <Flex align="center" gap="2">
                             <Crosshair1Icon className="w-4 h-4" />
                             <Text size="2">
                               {typeof user.location === "string"
-                                ? user.location || "No location provided"
-                                : (user.location as any)?.address ||
+                                  ? user.location || "No location provided"
+                                  : (user.location as any)?.address ||
                                   "No location provided"}
                             </Text>
                           </Flex>
-                        )}
-                      </div>
+                      )}
+                    </div>
 
-                      {/* Average Rating */}
-                      <div>
-                        <Text size="2" weight="bold" className="block mb-1">
-                          Average Rating
-                        </Text>
-                        {ratingCount > 0 && averageRating != null ? (
+                    {/* Average Rating */}
+                    <div>
+                      <Text size="2" weight="bold" className="block mb-1">
+                        Average Rating
+                      </Text>
+                      {ratingCount > 0 && averageRating != null ? (
                           <Flex align="center" gap="2">
                             <RatingStars
-                              value={Math.round(averageRating * 10) / 10}
-                              readonly
-                              size={18}
+                                value={Math.round(averageRating * 10) / 10}
+                                readonly
+                                size={18}
                             />
                             <Text size="2" color="gray">
                               {averageRating.toFixed(1)} ({ratingCount} rating
                               {ratingCount !== 1 ? "s" : ""})
                             </Text>
                           </Flex>
-                        ) : (
+                      ) : (
                           <Text size="2" color="gray">
                             No ratings yet
                           </Text>
-                        )}
-                      </div>
-
-                      <Separator />
-
-                      {/* Social Links */}
-                      <div>
-                        <Text size="2" weight="bold" className="block mb-2">
-                          Social Links
-                        </Text>
-                        {isEditing ? (
+                      )}
+                    </div>
+                    {/* Social Links */}
+                    <div>
+                      <Text size="2" weight="bold" className="block mb-2">
+                        Social Links
+                      </Text>
+                      {isEditing ? (
                           <div className="space-y-2">
                             {(
-                              [
                                 [
-                                  "linkedin",
-                                  "LinkedIn",
-                                  "https://linkedin.com/in/...",
-                                ],
-                                ["github", "GitHub", "https://github.com/..."],
-                                [
-                                  "twitter",
-                                  "Twitter / X",
-                                  "https://twitter.com/...",
-                                ],
-                                [
-                                  "instagram",
-                                  "Instagram",
-                                  "https://instagram.com/...",
-                                ],
-                                ["website", "Website", "https://yoursite.com"],
-                                [
-                                  "portfolio",
-                                  "Portfolio",
-                                  "https://portfolio.com",
-                                ],
-                              ] as const
+                                  [
+                                    "linkedin",
+                                    "LinkedIn",
+                                    "https://linkedin.com/in/...",
+                                  ],
+                                  ["github", "GitHub", "https://github.com/..."],
+                                  [
+                                    "twitter",
+                                    "Twitter / X",
+                                    "https://twitter.com/...",
+                                  ],
+                                  [
+                                    "instagram",
+                                    "Instagram",
+                                    "https://instagram.com/...",
+                                  ],
+                                  ["website", "Website", "https://yoursite.com"],
+                                  [
+                                    "portfolio",
+                                    "Portfolio",
+                                    "https://portfolio.com",
+                                  ],
+                                ] as const
                             ).map(([key, label, placeholder]) => (
-                              <div key={key}>
-                                <Text
-                                  size="1"
-                                  color="gray"
-                                  className="block mb-0.5"
-                                >
-                                  {label}
-                                </Text>
-                                <TextField.Root
-                                  value={
-                                    (editForm.social_links as any)[key] || ""
-                                  }
-                                  onChange={(e) =>
-                                    handleSocialLinkChange(
-                                      key as keyof SocialLinks,
-                                      e.target.value,
-                                    )
-                                  }
-                                  placeholder={placeholder}
-                                  size="1"
-                                />
-                              </div>
+                                <div key={key}>
+                                  <Text
+                                      size="1"
+                                      color="gray"
+                                      className="block mb-0.5"
+                                  >
+                                    {label}
+                                  </Text>
+                                  <TextField.Root
+                                      value={
+                                          (editForm.social_links as any)[key] || ""
+                                      }
+                                      onChange={(e) =>
+                                          handleSocialLinkChange(
+                                              key as keyof SocialLinks,
+                                              e.target.value,
+                                          )
+                                      }
+                                      placeholder={placeholder}
+                                      size="1"
+                                  />
+                                </div>
                             ))}
                           </div>
-                        ) : (
+                      ) : (
                           <Flex gap="3" wrap="wrap">
                             {user.social_links?.linkedin && (
-                              <a
-                                href={user.social_links.linkedin}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="LinkedIn"
-                              >
-                                <Linkedin
-                                  size={20}
-                                  className="text-gray-600 hover:text-blue-600 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.linkedin}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="LinkedIn"
+                                >
+                                  <Linkedin
+                                      size={20}
+                                      className="text-gray-600 hover:text-blue-600 transition-colors"
+                                  />
+                                </a>
                             )}
                             {user.social_links?.github && (
-                              <a
-                                href={user.social_links.github}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="GitHub"
-                              >
-                                <Github
-                                  size={20}
-                                  className="text-gray-600 hover:text-gray-900 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.github}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="GitHub"
+                                >
+                                  <Github
+                                      size={20}
+                                      className="text-gray-600 hover:text-gray-900 transition-colors"
+                                  />
+                                </a>
                             )}
                             {user.social_links?.twitter && (
-                              <a
-                                href={user.social_links.twitter}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Twitter / X"
-                              >
-                                <Twitter
-                                  size={20}
-                                  className="text-gray-600 hover:text-sky-500 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.twitter}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="Twitter / X"
+                                >
+                                  <Twitter
+                                      size={20}
+                                      className="text-gray-600 hover:text-sky-500 transition-colors"
+                                  />
+                                </a>
                             )}
                             {user.social_links?.instagram && (
-                              <a
-                                href={user.social_links.instagram}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Instagram"
-                              >
-                                <Instagram
-                                  size={20}
-                                  className="text-gray-600 hover:text-pink-500 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.instagram}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="Instagram"
+                                >
+                                  <Instagram
+                                      size={20}
+                                      className="text-gray-600 hover:text-pink-500 transition-colors"
+                                  />
+                                </a>
                             )}
                             {user.social_links?.website && (
-                              <a
-                                href={user.social_links.website}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Website"
-                              >
-                                <Globe
-                                  size={20}
-                                  className="text-gray-600 hover:text-green-600 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.website}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="Website"
+                                >
+                                  <Globe
+                                      size={20}
+                                      className="text-gray-600 hover:text-green-600 transition-colors"
+                                  />
+                                </a>
                             )}
                             {user.social_links?.portfolio && (
-                              <a
-                                href={user.social_links.portfolio}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Portfolio"
-                              >
-                                <Briefcase
-                                  size={20}
-                                  className="text-gray-600 hover:text-amber-600 transition-colors"
-                                />
-                              </a>
+                                <a
+                                    href={user.social_links.portfolio}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title="Portfolio"
+                                >
+                                  <Briefcase
+                                      size={20}
+                                      className="text-gray-600 hover:text-amber-600 transition-colors"
+                                  />
+                                </a>
                             )}
                             {!user.social_links?.linkedin &&
-                              !user.social_links?.github &&
-                              !user.social_links?.twitter &&
-                              !user.social_links?.instagram &&
-                              !user.social_links?.website &&
-                              !user.social_links?.portfolio && (
-                                <Text size="2" color="gray">
-                                  No social links added
-                                </Text>
-                              )}
+                                !user.social_links?.github &&
+                                !user.social_links?.twitter &&
+                                !user.social_links?.instagram &&
+                                !user.social_links?.website &&
+                                !user.social_links?.portfolio && (
+                                    <Text size="2" color="gray">
+                                      No social links added
+                                    </Text>
+                                )}
                           </Flex>
-                        )}
-                      </div>
+                      )}
+                    </div>
 
-                      <Separator />
+                    
 
-                      {/* Interests */}
-                      <div>
-                        <Flex justify="between" align="center" mb="3">
-                          <Text size="2" weight="bold">
-                            Interests
-                          </Text>
-                          <Button
+                    {/* Interests */}
+                    <div>
+                      <Flex justify="between" align="center" mb="3">
+                        <Text size="2" weight="bold">
+                          Interests
+                        </Text>
+                        <Button
                             size="1"
                             variant="soft"
                             color="lime"
                             className="rounded-full"
                             onClick={() => setShowInterestSelector(true)}
-                          >
-                            {(user.interests?.length || 0) > 0
+                        >
+                          {(user.interests?.length || 0) > 0
                               ? "Update Interests"
                               : "Add Interests"}
-                          </Button>
-                        </Flex>
-                        {(user.interests?.length || 0) > 0 ? (
+                        </Button>
+                      </Flex>
+                      {(user.interests?.length || 0) > 0 ? (
                           <Flex gap="2" wrap="wrap">
                             {user.interests!.map((interest) => (
-                              <InterestChip
-                                key={interest}
-                                name={interest}
-                                size="sm"
-                                showIcon
-                              />
+                                <InterestChip
+                                    key={interest}
+                                    name={interest}
+                                    size="sm"
+                                    showIcon
+                                />
                             ))}
                           </Flex>
-                        ) : (
+                      ) : (
                           <button
-                            type="button"
-                            onClick={() => setShowInterestSelector(true)}
-                            className="rounded-xl border-2 border-dashed px-4 py-3 text-left text-sm transition-colors"
-                            style={{
-                              borderColor: "var(--gray-6)",
-                              backgroundColor: "var(--gray-1)",
-                              color: "var(--gray-10)",
-                            }}
-                            onMouseEnter={(e) => {
-                              e.currentTarget.style.borderColor =
-                                "var(--lime-6)";
-                              e.currentTarget.style.backgroundColor =
-                                "var(--lime-2)";
-                              e.currentTarget.style.color = "var(--lime-11)";
-                            }}
-                            onMouseLeave={(e) => {
-                              e.currentTarget.style.borderColor =
-                                "var(--gray-6)";
-                              e.currentTarget.style.backgroundColor =
-                                "var(--gray-1)";
-                              e.currentTarget.style.color = "var(--gray-10)";
-                            }}
+                              type="button"
+                              onClick={() => setShowInterestSelector(true)}
+                              className="rounded-xl border-2 border-dashed px-4 py-3 text-left text-sm transition-colors"
+                              style={{
+                                borderColor: "var(--gray-6)",
+                                backgroundColor: "var(--gray-1)",
+                                color: "var(--gray-10)",
+                              }}
+                              onMouseEnter={(e) => {
+                                e.currentTarget.style.borderColor =
+                                    "var(--lime-6)";
+                                e.currentTarget.style.backgroundColor =
+                                    "var(--lime-2)";
+                                e.currentTarget.style.color = "var(--lime-11)";
+                              }}
+                              onMouseLeave={(e) => {
+                                e.currentTarget.style.borderColor =
+                                    "var(--gray-6)";
+                                e.currentTarget.style.backgroundColor =
+                                    "var(--gray-1)";
+                                e.currentTarget.style.color = "var(--gray-10)";
+                              }}
                           >
                             Add interests to help others discover you
                           </button>
-                        )}
-                      </div>
+                      )}
+                    </div>
 
-                      <Separator />
+                    
 
-                      {/* Communities */}
-                      {(userCommunitiesLoading || userCommunities.length > 0) && (
+                    {/* Communities */}
+                    {(userCommunitiesLoading || userCommunities.length > 0) && (
                         <div>
                           <Flex align="center" gap="2" className="mb-2">
                             <Text size="2" weight="bold">
                               Communities
                             </Text>
                             {!userCommunitiesLoading && (
-                              <Text size="1" color="gray">
-                                {userCommunities.length}
-                              </Text>
+                                <Text size="1" color="gray">
+                                  {userCommunities.length}
+                                </Text>
                             )}
                           </Flex>
                           {userCommunitiesLoading ? (
-                            <Text size="1" color="gray">
-                              Loading communities...
-                            </Text>
+                              <Text size="1" color="gray">
+                                Loading communities...
+                              </Text>
                           ) : (
-                            <Flex gap="2" wrap="wrap">
-                              {userCommunities.slice(0, 12).map((community) => (
-                                <button
-                                  key={community._id}
-                                  type="button"
-                                  title={community.name}
-                                  aria-label={`Open ${community.name}`}
-                                  onClick={() =>
-                                    navigate(`/forum/communities/${community._id}`)
-                                  }
-                                  className="rounded-full ring-1 ring-[var(--gray-6)] transition hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--grass-8)]"
-                                >
-                                  <Avatar
-                                    size="3"
-                                    src={getImageUrl(community.avatar_url)}
-                                    fallback={community.name[0]}
-                                    radius="full"
-                                  />
-                                </button>
-                              ))}
-                              {userCommunities.length > 12 && (
-                                <span
-                                  title={`${userCommunities.length - 12} more communities`}
-                                  className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--gray-3)] text-sm font-medium text-[var(--gray-11)] ring-1 ring-[var(--gray-6)]"
-                                >
+                              <Flex gap="2" wrap="wrap">
+                                {userCommunities.slice(0, 12).map((community) => (
+                                    <button
+                                        key={community._id}
+                                        type="button"
+                                        title={community.name}
+                                        aria-label={`Open ${community.name}`}
+                                        onClick={() =>
+                                            navigate(`/forum/communities/${community._id}`)
+                                        }
+                                        className="rounded-full ring-1 ring-[var(--gray-6)] transition hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--grass-8)]"
+                                    >
+                                      <Avatar
+                                          size="3"
+                                          src={getImageUrl(community.avatar_url)}
+                                          fallback={community.name[0]}
+                                          radius="full"
+                                      />
+                                    </button>
+                                ))}
+                                {userCommunities.length > 12 && (
+                                    <span
+                                        title={`${userCommunities.length - 12} more communities`}
+                                        className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--gray-3)] text-sm font-medium text-[var(--gray-11)] ring-1 ring-[var(--gray-6)]"
+                                    >
                                   +{userCommunities.length - 12}
                                 </span>
-                              )}
-                            </Flex>
+                                )}
+                              </Flex>
                           )}
                         </div>
-                      )}
+                    )}
 
-                      <Separator />
+                    
 
-                      {/* Stats */}
-                      <div className="space-y-2">
-                        <Flex justify="between" align="center">
-                          <Text size="2">TimeBank Balance</Text>
-                          <Text size="2" weight="bold">
-                            {user.timebank_balance} hours
-                          </Text>
-                        </Flex>
-                        <Flex justify="between" align="center">
-                          <Text size="2">Member Since</Text>
-                          <Text size="2">
-                            {new Date(user.created_at).toLocaleDateString()}
-                          </Text>
-                        </Flex>
-                        <Flex justify="between" align="center">
-                          <Text size="2">Status</Text>
-                          <Badge
+                    {/* Stats */}
+                    <div className="space-y-2">
+                      <Flex justify="between" align="center">
+                        <Text size="2">TimeBank Balance</Text>
+                        <Text size="2" weight="bold">
+                          {user.timebank_balance} hours
+                        </Text>
+                      </Flex>
+                      <Flex justify="between" align="center">
+                        <Text size="2">Member Since</Text>
+                        <Text size="2">
+                          {new Date(user.created_at).toLocaleDateString()}
+                        </Text>
+                      </Flex>
+                      <Flex justify="between" align="center">
+                        <Text size="2">Status</Text>
+                        <Badge
                             color={user.is_active ? "green" : "red"}
                             variant="soft"
-                          >
-                            {user.is_active ? "Active" : "Inactive"}
-                          </Badge>
-                        </Flex>
-                      </div>
+                        >
+                          {user.is_active ? "Active" : "Inactive"}
+                        </Badge>
+                      </Flex>
                     </div>
-                  </Card>
-                </Box>
+                  </div>
+                </Card>
+              </Box>
 
-                {/* Settings */}
-                <Box>
-                  <Card size="4" className="p-6">
-                    <Heading size="5" mb="4">
-                      Settings & Preferences
-                    </Heading>
-
-                    <div className="space-y-6">
-                      {/* Privacy Settings */}
-                      <div>
-                        <Heading size="4" mb="3">
-                          Privacy
-                        </Heading>
-                        <div className="space-y-3">
-                          {/*
-                    <Flex justify="between" align="center">
-                    <div className="grid gap-1">
-                      <Text size="2" weight="bold">
-                        Profile Visibility
-                      </Text>
-                      <Text size="1" color="gray">
-                        Make your profile visible to other users
-                      </Text>
-                    </div>
-                    <Switch
-                      checked={settings.profile_visible}
-                      onCheckedChange={(checked) =>
-                        handleSettingsChange("profile_visible", checked)
-                      }
-                      disabled={settingsLoading}
-                    />
-                  </Flex>
-                    */}
-                          <Flex justify="between" align="center">
-                            <div className="grid gap-1">
-                              <Text size="2" weight="bold">
-                                Show Email
-                              </Text>
-                              <Text size="1" color="gray">
-                                Display your email on your profile
-                              </Text>
-                            </div>
-                            <Switch
-                              checked={settings.show_email}
-                              onCheckedChange={(checked) =>
-                                handleSettingsChange("show_email", checked)
-                              }
-                              disabled={settingsLoading}
-                            />
-                          </Flex>
-                          <Flex justify="between" align="center">
-                            <div className="grid gap-1">
-                              <Text size="2" weight="bold">
-                                Show Location
-                              </Text>
-                              <Text size="1" color="gray">
-                                Display your location on your profile
-                              </Text>
-                            </div>
-                            <Switch
-                              checked={settings.show_location}
-                              onCheckedChange={(checked) =>
-                                handleSettingsChange("show_location", checked)
-                              }
-                              disabled={settingsLoading}
-                            />
-                          </Flex>
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Notification Settings */}
-                      <div>
-                        <Heading size="4" mb="3">
-                          Notifications
-                        </Heading>
-                        <div className="space-y-3">
-                          <Flex justify="between" align="center">
-                            <div className="grid gap-1">
-                              <Text size="2" weight="bold">
-                                Email Notifications
-                              </Text>
-                              <Text size="1" color="gray">
-                                Receive notifications via email
-                              </Text>
-                            </div>
-                            <Switch
-                              checked={settings.email_notifications}
-                              onCheckedChange={(checked) =>
-                                handleSettingsChange(
-                                  "email_notifications",
-                                  checked,
-                                )
-                              }
-                              disabled={settingsLoading}
-                            />
-                          </Flex>
-                          <Flex justify="between" align="center">
-                            <div className="grid gap-1">
-                              <Text size="2" weight="bold">
-                                Service Matches
-                              </Text>
-                              <Text size="1" color="gray">
-                                Get notified when services match your needs
-                              </Text>
-                            </div>
-                            <Switch
-                              checked={settings.service_matches_notifications}
-                              onCheckedChange={(checked) =>
-                                handleSettingsChange(
-                                  "service_matches_notifications",
-                                  checked,
-                                )
-                              }
-                              disabled={settingsLoading}
-                            />
-                          </Flex>
-                          <Flex justify="between" align="center">
-                            <div className="grid gap-1">
-                              <Text size="2" weight="bold">
-                                Messages
-                              </Text>
-                              <Text size="1" color="gray">
-                                Get notified about new messages
-                              </Text>
-                            </div>
-                            <Switch
-                              checked={settings.messages_notifications}
-                              onCheckedChange={(checked) =>
-                                handleSettingsChange(
-                                  "messages_notifications",
-                                  checked,
-                                )
-                              }
-                              disabled={settingsLoading}
-                            />
-                          </Flex>
-                        </div>
-                      </div>
-
-                      <Separator />
-
-                      {/* Account Settings */}
-                      <div>
-                        <Heading size="4" mb="3">
-                          Account
-                        </Heading>
-                        <div className="space-y-3">
-                          <Button
-                            variant="soft"
-                            size="2"
-                            className="w-full justify-start"
-                            onClick={() => setShowPasswordDialog(true)}
-                          >
-                            <LockClosedIcon className="w-4 h-4 mr-2" />
-                            Change Password
-                          </Button>
-                          <Button
-                            variant="soft"
-                            size="2"
-                            className="w-full justify-start"
-                            onClick={handleLogout}
-                          >
-                            <ExitIcon className="w-4 h-4 mr-2" />
-                            Logout
-                          </Button>
-                          <Button
-                            variant="soft"
-                            color="red"
-                            size="2"
-                            className="w-full justify-start"
-                            onClick={() => setShowDeleteDialog(true)}
-                          >
-                            Delete Account
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  </Card>
-                </Box>
-              </Grid>
               <BadgeDisplay />
 
               <ActivitySummarySection
@@ -1405,158 +1083,6 @@ export function Profile() {
         onSave={handleInterestsSave}
       />
 
-      {/* Change Password Dialog */}
-      <Dialog.Root
-        open={showPasswordDialog}
-        onOpenChange={setShowPasswordDialog}
-      >
-        <Dialog.Content className="max-w-md">
-          <Dialog.Title>Change Password</Dialog.Title>
-          <Dialog.Description className="mb-4">
-            Enter your current password and choose a new one.
-          </Dialog.Description>
-
-          <div className="space-y-4">
-            <div>
-              <Text size="2" weight="bold" className="block mb-1">
-                Current Password
-              </Text>
-              <TextField.Root
-                type="password"
-                value={passwordForm.current_password}
-                onChange={(e) =>
-                  setPasswordForm({
-                    ...passwordForm,
-                    current_password: e.target.value,
-                  })
-                }
-                placeholder="Enter current password"
-                size="2"
-              />
-            </div>
-
-            <div>
-              <Text size="2" weight="bold" className="block mb-1">
-                New Password
-              </Text>
-              <TextField.Root
-                type="password"
-                value={passwordForm.new_password}
-                onChange={(e) =>
-                  setPasswordForm({
-                    ...passwordForm,
-                    new_password: e.target.value,
-                  })
-                }
-                placeholder="Enter new password"
-                size="2"
-              />
-            </div>
-
-            <div>
-              <Text size="2" weight="bold" className="block mb-1">
-                Confirm New Password
-              </Text>
-              <TextField.Root
-                type="password"
-                value={passwordForm.confirm_password}
-                onChange={(e) =>
-                  setPasswordForm({
-                    ...passwordForm,
-                    confirm_password: e.target.value,
-                  })
-                }
-                placeholder="Confirm new password"
-                size="2"
-              />
-            </div>
-          </div>
-
-          <Flex gap="3" mt="4" justify="end">
-            <Button
-              variant="soft"
-              onClick={() => {
-                setShowPasswordDialog(false);
-                setPasswordForm({
-                  current_password: "",
-                  new_password: "",
-                  confirm_password: "",
-                });
-              }}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handlePasswordChange} disabled={passwordLoading}>
-              {passwordLoading ? "Changing..." : "Change Password"}
-            </Button>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
-
-      {/* Delete Account Dialog */}
-      <Dialog.Root open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <Dialog.Content className="max-w-md">
-          <Dialog.Title color="red">Delete Account</Dialog.Title>
-          <Dialog.Description className="mb-4">
-            This action cannot be undone. This will permanently delete your
-            account and all associated data.
-          </Dialog.Description>
-
-          <div className="space-y-4">
-            <div>
-              <Text size="2" weight="bold" className="block mb-1">
-                Enter your password to confirm
-              </Text>
-              <TextField.Root
-                type="password"
-                value={deleteForm.password}
-                onChange={(e) =>
-                  setDeleteForm({ ...deleteForm, password: e.target.value })
-                }
-                placeholder="Enter your password"
-                size="2"
-              />
-            </div>
-          </div>
-
-          <Flex gap="3" mt="4" justify="end">
-            <Button
-              variant="soft"
-              onClick={() => {
-                setShowDeleteDialog(false);
-                setDeleteForm({ password: "" });
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              color="red"
-              onClick={handleDeleteAccount}
-              disabled={deleteLoading}
-            >
-              {deleteLoading ? "Deleting..." : "Delete Account"}
-            </Button>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
-
-      <ConfirmDialog
-        open={deleteConfirmOpen}
-        onOpenChange={setDeleteConfirmOpen}
-        title="Delete your account?"
-        description="Are you sure you want to delete your account? This action cannot be undone."
-        confirmLabel="Delete account"
-        variant="danger"
-        onConfirm={handleConfirmDeleteAccount}
-      />
-      <ConfirmDialog
-        open={logoutConfirmOpen}
-        onOpenChange={setLogoutConfirmOpen}
-        title="Log out?"
-        description="Are you sure you want to logout?"
-        confirmLabel="Log out"
-        onConfirm={handleConfirmLogout}
-      />
       {/* Rejected Requests Dialog
 
        <Dialog.Root

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,13 @@
+import { Box, Heading } from "@radix-ui/themes";
+import { SettingsPanel } from "@/components/ui/SettingsPanel";
+
+export function Settings() {
+  return (
+    <Box className="py-8 px-4">
+      <Heading size="7" mb="6">
+        Settings
+      </Heading>
+      <SettingsPanel />
+    </Box>
+  );
+}


### PR DESCRIPTION
Closes #380 

          
                                                                                                                                                                                                                   
  **Summary**                                

                                                                                                                                                                                                                                               
  - Settings refactor: Extracted the Settings & Preferences section out of the Profile page into a standalone /settings route (accessible via the navbar gear icon for regular users). Admins get a "My Settings" tab inside the Admin Panel   
  instead. The shared SettingsPanel component handles privacy toggles, notification preferences, password change, logout, and account deletion.
  - Activity tab: Moved ActivitySummarySection from inside the Profile tab into its own dedicated Activity tab on the Profile page, giving it more visual space and reducing clutter on the main profile view.                                 
  - Mock data seed script: Added backend/scripts/seed_mock_data.py to populate the database with realistic test data for development.                                                                                                          
                                                                                                                                                                                                                                               
  **Test plan**                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                               
  - Log in as a regular user → navbar shows gear icon → navigates to /settings, all toggles and account actions work                                                                                                                           
  - Log in as admin/moderator → navbar gear icon navigates to /admin → "My Settings" tab visible and functional
  - Profile page no longer shows settings card; "Activity" tab loads transaction and rating history correctly                                                                                                                                  
  - Switching between profile tabs preserves lazy-load behaviour (visited tabs only)                                                                                                                                                           
  - Run seed script against a local MongoDB instance and verify collections are populated    
  
                 
<img width="1800" height="1021" alt="Screenshot 2026-05-04 at 20 01 58" src="https://github.com/user-attachments/assets/35d1dcbc-2135-442b-90f6-e33eac4093f8" />

<img width="1800" height="1013" alt="Screenshot 2026-05-04 at 20 01 54" src="https://github.com/user-attachments/assets/96e76460-308a-4256-9bf4-d8b8a875b5c5" />
