### PR TITLE
ci: add Codecov coverage reporting for backend and frontend

### DIFF
--- a/.github/workflows/deploy-easypanel.yml
+++ b/.github/workflows/deploy-easypanel.yml
@@ -26,7 +26,15 @@ jobs:
 
       - name: Run backend tests
         working-directory: backend
-        run: pytest -m "not integration" --no-cov
+        run: pytest -m "not integration" --cov=app --cov-report=xml --cov-report=html
+
+      - name: Upload backend coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -49,7 +57,15 @@ jobs:
 
       - name: Frontend tests
         working-directory: frontend
-        run: npm run test:run
+        run: npm run test:run -- --coverage
+
+      - name: Upload frontend coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: frontend/coverage/clover.xml
+          flags: frontend
+          fail_ci_if_error: false
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
  Adds Codecov integration to the CI pipeline so test coverage reports are visible as a live dashboard instead of downloadable zip artifacts.
                                                                                                                                                                                                                                               
  - Frontend Vitest runs with `--coverage`                                                             
  - Both reports are uploaded to Codecov via `codecov/codecov-action@v4` with separate `backend` and `frontend` flags                                                                                                                          
  - `fail_ci_if_error: false` — coverage upload failure never blocks deployment                                      
  - `continue-on-error: true` on the test job is preserved — deploy always runs regardless of test outcome                                                                                                                                     
                                                                                                          
  ## Screenshots                                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
  N/A — CI-only change, no visual output.                                                                                                                                                                                                      
                                                                                                                                                                                                                                               
  ## Test Plan                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                               
  1. Merge to `main` and observe the GitHub Actions run                                                                                                                                                                                        
  2. Confirm both `Upload backend coverage to Codecov` and `Upload frontend coverage to Codecov` steps pass
  3. Visit `codecov.io/gh/senaoz/SWE-574` and verify backend/frontend flags appear with coverage data                                                                                                                                          
                                                                                                     
                                                                                                     
- https://app.codecov.io/gh/senaoz/SWE-574/tree/main