### PR TITLE
Notify users when service posts match

### DIFF
--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -27,6 +27,7 @@ class NotificationType(str, Enum):
     SERVICE_COMPLETED = "service_completed"
     NEW_MESSAGE = "new_message"
     SERVICE_STARTED = "service_started"
+    SERVICE_MATCH = "service_match"
 
 
 class NotificationRelatedType(str, Enum):

--- a/backend/app/services/service_service.py
+++ b/backend/app/services/service_service.py
@@ -19,6 +19,7 @@ from ..core.database import get_database
 from .content_moderation_service import is_offensive
 
 PINNED_LIMIT = 2
+SERVICE_MATCH_NOTIFICATION_LIMIT = 5
 
 
 def _ensure_non_offensive(value: Optional[str], field_name: str) -> None:
@@ -283,6 +284,12 @@ class ServiceService:
     def _normalize_text_value(value: Optional[str]) -> str:
         return str(value or "").strip().lower()
 
+    @staticmethod
+    def _normalize_service_type_value(value) -> str:
+        if isinstance(value, ServiceType):
+            return value.value
+        return str(value or "").strip().lower()
+
     def _build_tag_filter_conditions(self, tags: List[str]) -> List[dict]:
         return [
             {"tags": {"$in": tags}},
@@ -461,7 +468,9 @@ class ServiceService:
     def _build_service_match_context(self, service_like: dict) -> dict:
         return {
             "title": str(service_like.get("title") or "").strip(),
-            "service_type": self._normalize_text_value(service_like.get("service_type")),
+            "service_type": self._normalize_service_type_value(
+                service_like.get("service_type")
+            ),
             "tags": self._get_tag_labels(service_like.get("tags")),
             "category": self._normalize_text_value(service_like.get("category")),
             "keywords": self._tokenize_text(
@@ -1148,6 +1157,143 @@ class ServiceService:
 
         return [], 0, "empty", show_profile_prompt
 
+    async def _user_wants_service_match_notifications(self, user_id: str) -> bool:
+        user_doc = await self.users_collection.find_one(
+            {"_id": self._normalize_object_id(user_id)},
+            {"service_matches_notifications": 1},
+        )
+        return bool((user_doc or {}).get("service_matches_notifications", True))
+
+    async def _get_service_match_notification_candidates(
+        self,
+        source_service_doc: dict,
+        limit: int = SERVICE_MATCH_NOTIFICATION_LIMIT,
+    ) -> List[Tuple[dict, float]]:
+        source_context = self._build_service_match_context(source_service_doc)
+        source_type = source_context.get("service_type")
+        if source_type == ServiceType.OFFER.value:
+            target_service_type = ServiceType.NEED
+        elif source_type == ServiceType.NEED.value:
+            target_service_type = ServiceType.OFFER
+        else:
+            return []
+
+        source_owner_id = str(source_service_doc.get("user_id"))
+        cursor = (
+            self.services_collection.find(
+                {
+                    "service_type": target_service_type,
+                    "status": ServiceStatus.ACTIVE,
+                }
+            )
+            .sort("created_at", -1)
+            .limit(200)
+        )
+
+        candidates: List[Tuple[dict, float]] = []
+        async for candidate_doc in cursor:
+            candidate_doc = self._normalize_service_doc(candidate_doc)
+            candidate_id = str(candidate_doc.get("_id"))
+            if candidate_id == str(source_service_doc.get("_id")):
+                continue
+            if str(candidate_doc.get("user_id")) == source_owner_id:
+                continue
+            if self._is_service_full(candidate_doc):
+                continue
+
+            score, _ = self._score_active_service_complement(
+                candidate_doc=candidate_doc,
+                active_service_contexts=[source_context],
+            )
+            if score >= 0.2:
+                candidates.append((candidate_doc, score))
+
+        candidates.sort(
+            key=lambda item: (
+                item[1],
+                item[0].get("created_at") or datetime.min,
+            ),
+            reverse=True,
+        )
+        return candidates[:limit]
+
+    async def _create_service_match_notification_if_needed(
+        self,
+        user_id: str,
+        title: str,
+        body: str,
+        related_id: str,
+    ) -> None:
+        if not await self._user_wants_service_match_notifications(user_id):
+            return
+
+        from .notification_service import NotificationService
+        from ..models.notification import NotificationType, NotificationRelatedType
+
+        existing = await self.db.notifications.find_one(
+            {
+                "user_id": self._normalize_object_id(user_id),
+                "type": NotificationType.SERVICE_MATCH,
+                "body": body,
+                "related_id": related_id,
+                "related_type": NotificationRelatedType.SERVICE,
+            },
+            {"_id": 1},
+        )
+        if existing:
+            return
+
+        notif_service = NotificationService(self.db)
+        await notif_service.create_notification(
+            user_id=user_id,
+            notification_type=NotificationType.SERVICE_MATCH,
+            title=title,
+            body=body,
+            related_id=related_id,
+            related_type=NotificationRelatedType.SERVICE,
+        )
+
+    async def _notify_service_matches_for_new_service(
+        self,
+        new_service_doc: dict,
+    ) -> None:
+        candidates = await self._get_service_match_notification_candidates(
+            new_service_doc
+        )
+        if not candidates:
+            return
+
+        new_service_id = str(new_service_doc.get("_id"))
+        new_owner_id = str(new_service_doc.get("user_id"))
+        new_title = str(new_service_doc.get("title") or "A service")
+        new_type = self._normalize_service_type_value(
+            new_service_doc.get("service_type")
+        )
+
+        top_candidate_doc = candidates[0][0]
+        top_candidate_id = str(top_candidate_doc.get("_id"))
+        top_candidate_title = str(top_candidate_doc.get("title") or "a service")
+
+        await self._create_service_match_notification_if_needed(
+            user_id=new_owner_id,
+            title="New service match",
+            body=f"'{top_candidate_title}' matches your {new_type} '{new_title}'",
+            related_id=top_candidate_id,
+        )
+
+        for candidate_doc, _ in candidates:
+            candidate_owner_id = str(candidate_doc.get("user_id"))
+            candidate_title = str(candidate_doc.get("title") or "your service")
+            candidate_type = self._normalize_service_type_value(
+                candidate_doc.get("service_type")
+            )
+            await self._create_service_match_notification_if_needed(
+                user_id=candidate_owner_id,
+                title="New service match",
+                body=f"'{new_title}' matches your {candidate_type} '{candidate_title}'",
+                related_id=new_service_id,
+            )
+
     async def create_service(self, service_data: ServiceCreate, user_id: str) -> ServiceResponse:
         """Create a new service"""
         try:
@@ -1213,6 +1359,11 @@ class ServiceService:
 
             # Convert GeoJSON back for response
             service_doc = self._normalize_service_doc(service_doc)
+
+            try:
+                await self._notify_service_matches_for_new_service(service_doc)
+            except Exception as e:
+                print(f"Warning: Failed to send service match notifications: {e}")
 
             return ServiceResponse(**service_doc)
         except Exception as e:

--- a/backend/tests/test_service_service.py
+++ b/backend/tests/test_service_service.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime, timedelta
 from app.services.service_service import ServiceService
 from app.models.service import ServiceCreate, ServiceUpdate, ServiceStatus, ServiceType, ServiceFilters
+from app.models.notification import NotificationType
 from app.models.user import UserRole
 
 
@@ -21,6 +22,130 @@ class TestServiceService:
         assert service.user_id == str(test_user.id)
         assert service.status == ServiceStatus.ACTIVE
         assert service.created_at is not None
+
+    @pytest.mark.asyncio
+    async def test_create_service_sends_notifications_for_for_you_complements(
+        self, mock_db, test_user, second_user, sample_service_data
+    ):
+        """Creating a matching opposite-type post should notify both service owners."""
+        from bson import ObjectId
+
+        service_service = ServiceService(mock_db)
+
+        offer_data = sample_service_data.copy()
+        offer_data.update(
+            {
+                "title": "Book Swap Offer",
+                "description": "I can lend and discuss novels with neighbors.",
+                "category": "books",
+                "tags": ["books", "reading"],
+                "service_type": "offer",
+                "estimated_duration": 1.0,
+            }
+        )
+        offer = await service_service.create_service(
+            ServiceCreate(**offer_data),
+            str(test_user.id),
+        )
+
+        need_data = sample_service_data.copy()
+        need_data.update(
+            {
+                "title": "Book Reading Need",
+                "description": "Looking for someone who can share book recommendations.",
+                "category": "books",
+                "tags": ["books", "reading"],
+                "service_type": "need",
+                "estimated_duration": 1.0,
+            }
+        )
+        need = await service_service.create_service(
+            ServiceCreate(**need_data),
+            str(second_user.id),
+        )
+
+        existing_owner_notification = await mock_db.notifications.find_one(
+            {
+                "user_id": ObjectId(str(test_user.id)),
+                "type": NotificationType.SERVICE_MATCH,
+            }
+        )
+        new_owner_notification = await mock_db.notifications.find_one(
+            {
+                "user_id": ObjectId(str(second_user.id)),
+                "type": NotificationType.SERVICE_MATCH,
+            }
+        )
+
+        assert existing_owner_notification is not None
+        assert existing_owner_notification["related_id"] == str(need.id)
+        assert "Book Reading Need" in existing_owner_notification["body"]
+
+        assert new_owner_notification is not None
+        assert new_owner_notification["related_id"] == str(offer.id)
+        assert "Book Swap Offer" in new_owner_notification["body"]
+
+    @pytest.mark.asyncio
+    async def test_create_service_respects_service_match_notification_preference(
+        self, mock_db, test_user, second_user, sample_service_data
+    ):
+        """Users who disable Service Matches should not receive match notifications."""
+        from bson import ObjectId
+
+        service_service = ServiceService(mock_db)
+        await mock_db.users.update_one(
+            {"_id": ObjectId(str(test_user.id))},
+            {"$set": {"service_matches_notifications": False}},
+        )
+
+        offer_data = sample_service_data.copy()
+        offer_data.update(
+            {
+                "title": "Book Lending Offer",
+                "description": "I can lend books and help pick your next read.",
+                "category": "books",
+                "tags": ["books", "reading"],
+                "service_type": "offer",
+                "estimated_duration": 1.0,
+            }
+        )
+        offer = await service_service.create_service(
+            ServiceCreate(**offer_data),
+            str(test_user.id),
+        )
+
+        need_data = sample_service_data.copy()
+        need_data.update(
+            {
+                "title": "Book Borrowing Need",
+                "description": "I need help finding and borrowing a good novel.",
+                "category": "books",
+                "tags": ["books", "reading"],
+                "service_type": "need",
+                "estimated_duration": 1.0,
+            }
+        )
+        await service_service.create_service(
+            ServiceCreate(**need_data),
+            str(second_user.id),
+        )
+
+        disabled_user_notification = await mock_db.notifications.find_one(
+            {
+                "user_id": ObjectId(str(test_user.id)),
+                "type": NotificationType.SERVICE_MATCH,
+            }
+        )
+        enabled_user_notification = await mock_db.notifications.find_one(
+            {
+                "user_id": ObjectId(str(second_user.id)),
+                "type": NotificationType.SERVICE_MATCH,
+            }
+        )
+
+        assert disabled_user_notification is None
+        assert enabled_user_notification is not None
+        assert enabled_user_notification["related_id"] == str(offer.id)
     
     @pytest.mark.asyncio
     async def test_get_service_by_id(self, mock_db, sample_service):

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -721,7 +721,8 @@ export type NotificationType =
   | 'transaction_completed'
   | 'service_completed'
   | 'new_message'
-  | 'service_started';
+  | 'service_started'
+  | 'service_match';
 
 export type NotificationRelatedType = 'service' | 'join_request' | 'transaction' | 'chat_room';
 


### PR DESCRIPTION
Closes #422 

## Description

Adds service match notifications for matching offer/need service posts.

- Added a new `service_match` notification type.
- Reused the existing For You complement matching logic for active service posts.
- When a new service post is created, the backend now checks matching opposite-type active services and creates notifications for relevant users.
- Respects each user’s `service_matches_notifications` setting, so users who disabled Service Matches do not receive these notifications.
- Added backend tests for both successful match notifications and disabled notification preferences.
- Updated frontend notification typing to include `service_match`.

This currently applies only to service posts (`offer` / `need`), not events, discussions, or communities.

## Screenshots

<img width="349" height="166" alt="Ekran Resmi 2026-05-08 ÖS 8 57 27" src="https://github.com/user-attachments/assets/d90d7b42-b792-4206-9dbe-15fc7ef893ce" />

<img width="353" height="173" alt="Ekran Resmi 2026-05-08 ÖS 8 57 04" src="https://github.com/user-attachments/assets/059e0a1a-d446-4ceb-b1df-1af340cdbd1f" />


## Test Plan

Automated Checks

Ran frontend type-checking to verify the new service_match notification type is accepted by the TypeScript models.

npm run --prefix frontend type-check

Ran focused backend service and notification tests.

./backend/.venv/bin/python -m pytest backend/tests/test_service_service.py backend/tests/test_notification_service.py

Results: 53 passed

Ran service API tests to confirm existing service create, list, detail, match, and recommendation flows still work with the new notification hook.

./backend/.venv/bin/python -m pytest backend/tests/test_services_api.py

Results:22 passed

Scenarios Covered
Created an active offer service post and then a matching active need service post with overlapping category and tags.

Verified that both relevant users receive a service_match notification.

Verified that the notification stores related_type=service and related_id for the matched service post.

Disabled service_matches_notifications for one user.

Verified that the opted-out user does not receive a service match notification.

Verified that the opted-in user still receives the matching notification.

Confirmed that existing notification behavior, including unread counts and notification listing, continues to pass existing tests.