### PR TITLE
Add reccomendation feature to the mobile and services like this to the service detail page

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.hive.hive_app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 11
-        versionName = "1.1.11"
+        versionCode = 12
+        versionName = "1.1.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BASE_URL", "\"https://backend-swe.gnahh5.easypanel.host\"")

--- a/app/app/src/main/java/com/hive/hive_app/data/api/ServicesApi.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/api/ServicesApi.kt
@@ -2,6 +2,7 @@ package com.hive.hive_app.data.api
 
 import com.hive.hive_app.data.api.dto.ServiceCreate
 import com.hive.hive_app.data.api.dto.ServiceListResponse
+import com.hive.hive_app.data.api.dto.RecommendedServiceListResponse
 import com.hive.hive_app.data.api.dto.ServiceResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -62,4 +63,13 @@ interface ServicesApi {
 
     @GET("services/saved/ids")
     suspend fun getSavedServiceIds(): Response<List<String>>
+
+    @GET("services/recommendations")
+    suspend fun getRecommendedServices(
+        @Query("page") page: Int = 1,
+        @Query("limit") limit: Int = 5,
+        @Query("latitude") latitude: Double? = null,
+        @Query("longitude") longitude: Double? = null,
+        @Query("radius") radius: Double? = null
+    ): Response<RecommendedServiceListResponse>
 }

--- a/app/app/src/main/java/com/hive/hive_app/data/api/dto/ServiceDto.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/api/dto/ServiceDto.kt
@@ -109,3 +109,21 @@ data class ServiceListResponse(
     val page: Int,
     val limit: Int
 )
+
+@JsonClass(generateAdapter = true)
+data class RecommendedServiceItemDto(
+    val service: ServiceResponse,
+    val reason: String,
+    val score: Double,
+    @Json(name = "matched_interests") val matchedInterests: List<String> = emptyList()
+)
+
+@JsonClass(generateAdapter = true)
+data class RecommendedServiceListResponse(
+    val items: List<RecommendedServiceItemDto>,
+    val total: Int,
+    val page: Int,
+    val limit: Int,
+    @Json(name = "recommendation_mode") val recommendationMode: String = "empty",
+    @Json(name = "show_profile_prompt") val showProfilePrompt: Boolean = false
+)

--- a/app/app/src/main/java/com/hive/hive_app/data/repository/ServicesRepository.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/repository/ServicesRepository.kt
@@ -2,6 +2,7 @@ package com.hive.hive_app.data.repository
 
 import com.hive.hive_app.data.api.ServicesApi
 import com.hive.hive_app.data.api.dto.LocationDto
+import com.hive.hive_app.data.api.dto.RecommendedServiceListResponse
 import com.hive.hive_app.data.api.dto.RecurringPatternDto
 import com.hive.hive_app.data.api.dto.ServiceCreate
 import com.hive.hive_app.data.api.dto.ServiceResponse
@@ -190,6 +191,30 @@ class ServicesRepository @Inject constructor(
             val response = servicesApi.getSavedServiceIds()
             if (response.isSuccessful && response.body() != null) Result.success(response.body()!!)
             else Result.failure(HttpException(response))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getRecommendedServices(
+        page: Int = 1,
+        limit: Int = 5,
+        latitude: Double? = null,
+        longitude: Double? = null,
+        radius: Double? = null
+    ): Result<RecommendedServiceListResponse> {
+        return try {
+            val response = servicesApi.getRecommendedServices(
+                page = page,
+                limit = limit,
+                latitude = latitude,
+                longitude = longitude,
+                radius = radius
+            )
+            if (response.isSuccessful && response.body() != null) Result.success(response.body()!!)
+            else Result.failure(HttpException(response))
+        } catch (e: IOException) {
+            Result.failure(e)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/app/src/main/java/com/hive/hive_app/navigation/MainScaffold.kt
+++ b/app/app/src/main/java/com/hive/hive_app/navigation/MainScaffold.kt
@@ -169,6 +169,7 @@ fun MainScaffold(
                     isSaved = detailIsSaved,
                     onStartChat = onStartChat,
                     onOpenUserProfile = { pushOverlay(OverlayRoute.UserProfile(it)) },
+                    onOpenRecommendedService = { pushOverlay(OverlayRoute.ServiceDetail(it)) },
                     onManageJoinRequests = { detailState?._id?.let { pushOverlay(OverlayRoute.ManageService(it)) } }
                 )
             }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ActiveItemsScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ActiveItemsScreen.kt
@@ -162,6 +162,7 @@ fun ActiveItemsScreen(
             isSaved = detailIsSaved,
             onStartChat = onStartChat,
             onOpenUserProfile = onOpenUserProfile,
+            onOpenRecommendedService = { selectedServiceId = it },
             onManageJoinRequests = {
                 manageRequestsServiceId = id
                 selectedServiceId = null

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/DiscoverScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/DiscoverScreen.kt
@@ -167,6 +167,7 @@ fun DiscoverScreen(
             isSaved = detailIsSaved,
             onStartChat = onStartChat,
             onOpenUserProfile = onOpenUserProfile,
+            onOpenRecommendedService = { selectedServiceId = it },
             onManageJoinRequests = {
                 manageRequestsServiceId = id
                 selectedServiceId = null

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
@@ -28,7 +28,9 @@ import androidx.compose.foundation.border
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.Search
@@ -533,6 +535,7 @@ fun MapScreen(
     var didInitialCenter by remember { mutableStateOf(false) }
     var nearMeCenterNonce by remember { mutableStateOf(0) }
     var showListView by remember { mutableStateOf(false) }
+    var showRecommendations by remember { mutableStateOf(false) }
 
     LaunchedEffect(resetNonce) {
         // "Map" tab reselected from bottom bar: return to the map root UI.
@@ -544,16 +547,19 @@ fun MapScreen(
         completeServiceRatingArgs = null
         showFilters = false
         showListView = false
+        showRecommendations = false
     }
 
     BackHandler(
         enabled = completeServiceRatingArgs != null ||
+            showRecommendations ||
             manageRequestsServiceId != null ||
             showCreateServiceScreen ||
             selectedServiceId != null ||
             selectedForumEventId != null
     ) {
         when {
+            showRecommendations -> showRecommendations = false
             completeServiceRatingArgs != null -> completeServiceRatingArgs = null
             manageRequestsServiceId != null -> manageRequestsServiceId = null
             showCreateServiceScreen -> {
@@ -700,7 +706,7 @@ fun MapScreen(
     var mapUiReady by remember { mutableStateOf(false) }
     val activity = LocalActivity.current
 
-    BackHandler(enabled = showListView) {
+    BackHandler(enabled = showListView && !showRecommendations) {
         showListView = false
     }
 
@@ -717,7 +723,16 @@ fun MapScreen(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        if (showListView) {
+        if (showRecommendations) {
+            RecommendationScreen(
+                modifier = Modifier.fillMaxSize(),
+                onBack = { showRecommendations = false },
+                onServiceSelected = { serviceId ->
+                    showRecommendations = false
+                    if (onServiceSelected != null) onServiceSelected(serviceId) else selectedServiceId = serviceId
+                }
+            )
+        } else if (showListView) {
             DiscoverScreen(
                 modifier = Modifier.fillMaxSize(),
                 onStartChat = onStartChat,
@@ -1039,9 +1054,31 @@ fun MapScreen(
                         ),
                         textStyle = MaterialTheme.typography.bodyMedium
                     )
+                    // Recommendation icon — left of list/discovery toggle
+                    IconButton(
+                        onClick = {
+                            showRecommendations = !showRecommendations
+                            if (showRecommendations) {
+                                showListView = false
+                                showFilters = false
+                            }
+                        },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (showRecommendations) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                            contentDescription = "Recommendations",
+                            tint = if (showRecommendations) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                     // List view toggle
                     IconButton(
-                        onClick = { showListView = !showListView },
+                        onClick = {
+                            showListView = !showListView
+                            if (showListView) showRecommendations = false
+                        },
                         modifier = Modifier.size(40.dp)
                     ) {
                         Icon(

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/MapScreen.kt
@@ -678,6 +678,7 @@ fun MapScreen(
             isSaved = detailIsSaved,
             onStartChat = onStartChat,
             onOpenUserProfile = onOpenUserProfile,
+            onOpenRecommendedService = { selectedServiceId = it },
             onManageJoinRequests = {
                 manageRequestsServiceId = id
                 selectedServiceId = null

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationScreen.kt
@@ -24,18 +24,21 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -47,25 +50,23 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.hive.hive_app.data.api.dto.RecommendedServiceItemDto
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecommendationScreen(
     modifier: Modifier = Modifier,
     viewModel: RecommendationViewModel = hiltViewModel(),
     onBack: () -> Unit,
-    onServiceSelected: (String) -> Unit
+    onServiceSelected: (String) -> Unit,
+    bottomBarPadding: Dp = 96.dp
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
-    val permissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
-        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        viewModel.setLocationPermissionGranted(granted)
-    }
 
     LaunchedEffect(Unit) {
         val granted = androidx.core.content.ContextCompat.checkSelfPermission(
@@ -73,9 +74,7 @@ fun RecommendationScreen(
             android.Manifest.permission.ACCESS_COARSE_LOCATION
         ) == android.content.pm.PackageManager.PERMISSION_GRANTED
         viewModel.setLocationPermissionGranted(granted)
-        if (!granted) {
-            permissionLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
-        }
+        viewModel.loadInitial()
     }
 
     Scaffold(
@@ -84,15 +83,28 @@ fun RecommendationScreen(
             RecommendationTopBar(onBack = onBack)
         }
     ) { innerPadding ->
+        val systemBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        val safeBottomPadding = bottomBarPadding + systemBottomInset
         when {
             state.isLoading -> {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding),
+                        .padding(innerPadding)
+                        .padding(bottom = safeBottomPadding),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        CircularProgressIndicator()
+                        Text(
+                            text = "Finding services for you...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
 
@@ -100,7 +112,8 @@ fun RecommendationScreen(
                 MessageState(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding),
+                        .padding(innerPadding)
+                        .padding(bottom = safeBottomPadding),
                     title = "Could not load recommendations",
                     body = state.error ?: "Please try again.",
                     actionLabel = "Retry",
@@ -112,7 +125,8 @@ fun RecommendationScreen(
                 MessageState(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding),
+                        .padding(innerPadding)
+                        .padding(bottom = safeBottomPadding),
                     title = "No recommendations yet",
                     body = "Create or engage with services to get smarter personalized suggestions.",
                     actionLabel = "Refresh",
@@ -121,45 +135,49 @@ fun RecommendationScreen(
             }
 
             else -> {
-                val systemBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-                LazyColumn(
+                PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = { viewModel.refresh() },
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding),
-                    contentPadding = PaddingValues(
-                        start = 16.dp,
-                        end = 16.dp,
-                        top = 12.dp,
-                        bottom = 16.dp + systemBottomInset
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                        .padding(innerPadding)
                 ) {
-                    item {
-                        RecommendationHeader(
-                            count = state.items.size,
-                            recommendationMode = state.recommendationMode
-                        )
-                    }
-                    items(items = state.items, key = { it.service._id }) { item ->
-                        RecommendationCard(
-                            item = item,
-                            onOpen = { onServiceSelected(item.service._id) }
-                        )
-                    }
-                    if (state.showProfilePrompt) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = 16.dp,
+                            end = 16.dp,
+                            top = 12.dp,
+                            bottom = 16.dp + safeBottomPadding
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
                         item {
-                            Card(
-                                shape = RoundedCornerShape(14.dp),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                                )
-                            ) {
-                                Text(
-                                    text = "Add more profile interests to improve recommendation quality.",
-                                    modifier = Modifier.padding(14.dp),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
+                            RecommendationHeader(
+                                count = state.items.size,
+                                recommendationMode = state.recommendationMode,
+                                onRefresh = { viewModel.refresh() }
+                            )
+                        }
+                        items(items = state.items, key = { it.service._id }) { item ->
+                            RecommendationCard(
+                                item = item,
+                                onOpen = { onServiceSelected(item.service._id) }
+                            )
+                        }
+                        if (state.showProfilePrompt) {
+                            item {
+                                Surface(
+                                    shape = RoundedCornerShape(14.dp),
+                                    color = MaterialTheme.colorScheme.secondaryContainer
+                                ) {
+                                    Text(
+                                        text = "Tip: add interests in your profile to improve recommendation quality.",
+                                        modifier = Modifier.padding(14.dp),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                                    )
+                                }
                             }
                         }
                     }
@@ -188,27 +206,47 @@ private fun RecommendationTopBar(
 @Composable
 private fun RecommendationHeader(
     count: Int,
-    recommendationMode: String
+    recommendationMode: String,
+    onRefresh: () -> Unit
 ) {
     val modeText = when (recommendationMode) {
-        "personalized" -> "Personalized for you"
-        "location_fallback" -> "Based on your location"
-        else -> "Suggestions for you"
+        "personalized" -> "Based on your interests and activity"
+        "location_fallback" -> "Based on nearby opportunities"
+        else -> "Suggestions tailored for you"
     }
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surface
     ) {
-        Text(
-            text = "Top $count services",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold
-        )
-        Text(
-            text = modeText,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "Recommended for you",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = "$count picks • $modeText",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = onRefresh) {
+                Icon(
+                    imageVector = Icons.Outlined.Refresh,
+                    contentDescription = "Refresh recommendations"
+                )
+            }
+        }
     }
 }
 
@@ -222,14 +260,14 @@ private fun RecommendationCard(
     Card(
         onClick = onOpen,
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             if (imageModel != null) {
                 AsyncImage(
@@ -238,52 +276,24 @@ private fun RecommendationCard(
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(156.dp)
+                        .height(164.dp)
                         .clip(RoundedCornerShape(12.dp))
                 )
             } else {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(96.dp)
+                        .height(118.dp)
                         .clip(RoundedCornerShape(12.dp))
-                        .background(MaterialTheme.colorScheme.surface),
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
+                        contentDescription = "No image available",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Favorite,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(18.dp)
-                )
-                Text(
-                    text = "Why recommended",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-            }
-            Card(
-                shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-            ) {
-                Text(
-                    text = item.reason,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
             }
             Text(
                 text = item.service.title,
@@ -292,11 +302,30 @@ private fun RecommendationCard(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Favorite,
+                    contentDescription = "Recommendation reason",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp)
+                )
+                Text(
+                    text = item.reason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
             Text(
                 text = item.service.description,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 3,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
             Row(
@@ -308,12 +337,14 @@ private fun RecommendationCard(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    FilterChip(
-                        selected = true,
-                        onClick = {},
-                        enabled = false,
-                        label = { Text(item.service.serviceType.replaceFirstChar { it.uppercase() }) }
-                    )
+                    Surface(shape = RoundedCornerShape(999.dp), color = MaterialTheme.colorScheme.primaryContainer) {
+                        Text(
+                            text = item.service.serviceType.replaceFirstChar { it.uppercase() },
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
                     if (!item.service.isRemote) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
@@ -362,26 +393,36 @@ private fun MessageState(
     onAction: () -> Unit
 ) {
     Box(
-        modifier = modifier.padding(24.dp),
+        modifier = modifier.padding(horizontal = 20.dp),
         contentAlignment = Alignment.Center
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surface
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
-            Text(
-                text = body,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.size(4.dp))
-            Button(onClick = onAction) {
-                Text(actionLabel)
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 18.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = onAction) {
+                        Text(actionLabel)
+                    }
+                    Button(onClick = onAction) {
+                        Text("Try now")
+                    }
+                }
             }
         }
     }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationScreen.kt
@@ -1,0 +1,388 @@
+package com.hive.hive_app.ui.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.hive.hive_app.data.api.dto.RecommendedServiceItemDto
+
+@Composable
+fun RecommendationScreen(
+    modifier: Modifier = Modifier,
+    viewModel: RecommendationViewModel = hiltViewModel(),
+    onBack: () -> Unit,
+    onServiceSelected: (String) -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    val permissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        viewModel.setLocationPermissionGranted(granted)
+    }
+
+    LaunchedEffect(Unit) {
+        val granted = androidx.core.content.ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        viewModel.setLocationPermissionGranted(granted)
+        if (!granted) {
+            permissionLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            RecommendationTopBar(onBack = onBack)
+        }
+    ) { innerPadding ->
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            state.error != null -> {
+                MessageState(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    title = "Could not load recommendations",
+                    body = state.error ?: "Please try again.",
+                    actionLabel = "Retry",
+                    onAction = { viewModel.refresh() }
+                )
+            }
+
+            state.items.isEmpty() -> {
+                MessageState(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    title = "No recommendations yet",
+                    body = "Create or engage with services to get smarter personalized suggestions.",
+                    actionLabel = "Refresh",
+                    onAction = { viewModel.refresh() }
+                )
+            }
+
+            else -> {
+                val systemBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 12.dp,
+                        bottom = 16.dp + systemBottomInset
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    item {
+                        RecommendationHeader(
+                            count = state.items.size,
+                            recommendationMode = state.recommendationMode
+                        )
+                    }
+                    items(items = state.items, key = { it.service._id }) { item ->
+                        RecommendationCard(
+                            item = item,
+                            onOpen = { onServiceSelected(item.service._id) }
+                        )
+                    }
+                    if (state.showProfilePrompt) {
+                        item {
+                            Card(
+                                shape = RoundedCornerShape(14.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                )
+                            ) {
+                                Text(
+                                    text = "Add more profile interests to improve recommendation quality.",
+                                    modifier = Modifier.padding(14.dp),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecommendationTopBar(
+    onBack: () -> Unit
+) {
+    TopAppBar(
+        modifier = Modifier.statusBarsPadding(),
+        title = { Text("Recommendations") },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+            }
+        }
+    )
+}
+
+@Composable
+private fun RecommendationHeader(
+    count: Int,
+    recommendationMode: String
+) {
+    val modeText = when (recommendationMode) {
+        "personalized" -> "Personalized for you"
+        "location_fallback" -> "Based on your location"
+        else -> "Suggestions for you"
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = "Top $count services",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = modeText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun RecommendationCard(
+    item: RecommendedServiceItemDto,
+    onOpen: () -> Unit
+) {
+    val context = LocalContext.current
+    val imageModel = buildImageRequest(context, item.service.imageUrls?.firstOrNull())
+    Card(
+        onClick = onOpen,
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (imageModel != null) {
+                AsyncImage(
+                    model = imageModel,
+                    contentDescription = item.service.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(156.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surface),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Image,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Favorite,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp)
+                )
+                Text(
+                    text = "Why recommended",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            Card(
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Text(
+                    text = item.reason,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            Text(
+                text = item.service.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = item.service.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    FilterChip(
+                        selected = true,
+                        onClick = {},
+                        enabled = false,
+                        label = { Text(item.service.serviceType.replaceFirstChar { it.uppercase() }) }
+                    )
+                    if (!item.service.isRemote) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(3.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.LocationOn,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "In person",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = "Remote",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+            if (item.matchedInterests.isNotEmpty()) {
+                Text(
+                    text = "Matched: ${item.matchedInterests.take(2).joinToString(", ")}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageState(
+    modifier: Modifier = Modifier,
+    title: String,
+    body: String,
+    actionLabel: String,
+    onAction: () -> Unit
+) {
+    Box(
+        modifier = modifier.padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.size(4.dp))
+            Button(onClick = onAction) {
+                Text(actionLabel)
+            }
+        }
+    }
+}

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationViewModel.kt
@@ -1,0 +1,113 @@
+package com.hive.hive_app.ui.main
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hive.hive_app.data.api.dto.RecommendedServiceItemDto
+import com.hive.hive_app.data.repository.ServicesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class RecommendationViewModel @Inject constructor(
+    private val servicesRepository: ServicesRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    data class RecommendationState(
+        val items: List<RecommendedServiceItemDto> = emptyList(),
+        val recommendationMode: String = "empty",
+        val showProfilePrompt: Boolean = false,
+        val isLoading: Boolean = false,
+        val error: String? = null,
+        val locationPermissionGranted: Boolean = false
+    )
+
+    private val _state = MutableStateFlow(RecommendationState())
+    val state: StateFlow<RecommendationState> = _state.asStateFlow()
+
+    private val locationManager: LocationManager?
+        get() = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+
+    fun setLocationPermissionGranted(granted: Boolean) {
+        _state.update { it.copy(locationPermissionGranted = granted) }
+        if (granted) {
+            refreshWithLocation()
+        } else {
+            loadRecommendations()
+        }
+    }
+
+    fun refresh() {
+        if (_state.value.locationPermissionGranted) {
+            refreshWithLocation()
+        } else {
+            loadRecommendations()
+        }
+    }
+
+    private fun refreshWithLocation() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            loadRecommendations()
+            return
+        }
+        viewModelScope.launch {
+            val location = withContext(Dispatchers.IO) {
+                locationManager?.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
+                    ?: locationManager?.getLastKnownLocation(LocationManager.PASSIVE_PROVIDER)
+            }
+            loadRecommendations(
+                latitude = location?.latitude,
+                longitude = location?.longitude
+            )
+        }
+    }
+
+    private fun loadRecommendations(
+        latitude: Double? = null,
+        longitude: Double? = null
+    ) {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+            val result = servicesRepository.getRecommendedServices(
+                page = 1,
+                limit = 5,
+                latitude = latitude,
+                longitude = longitude
+            )
+            result.fold(
+                onSuccess = { response ->
+                    _state.update {
+                        it.copy(
+                            items = response.items.take(5),
+                            recommendationMode = response.recommendationMode,
+                            showProfilePrompt = response.showProfilePrompt,
+                            isLoading = false,
+                            error = null
+                        )
+                    }
+                },
+                onFailure = { failure ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            error = failure.message ?: "Failed to load recommendations"
+                        )
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/RecommendationViewModel.kt
@@ -31,6 +31,8 @@ class RecommendationViewModel @Inject constructor(
         val recommendationMode: String = "empty",
         val showProfilePrompt: Boolean = false,
         val isLoading: Boolean = false,
+        val isRefreshing: Boolean = false,
+        val hasLoadedOnce: Boolean = false,
         val error: String? = null,
         val locationPermissionGranted: Boolean = false
     )
@@ -44,23 +46,32 @@ class RecommendationViewModel @Inject constructor(
     fun setLocationPermissionGranted(granted: Boolean) {
         _state.update { it.copy(locationPermissionGranted = granted) }
         if (granted) {
-            refreshWithLocation()
+            refreshWithLocation(isPullToRefresh = false)
         } else {
-            loadRecommendations()
+            loadRecommendations(isPullToRefresh = false)
         }
     }
 
     fun refresh() {
         if (_state.value.locationPermissionGranted) {
-            refreshWithLocation()
+            refreshWithLocation(isPullToRefresh = true)
         } else {
-            loadRecommendations()
+            loadRecommendations(isPullToRefresh = true)
         }
     }
 
-    private fun refreshWithLocation() {
+    fun loadInitial() {
+        if (_state.value.hasLoadedOnce) return
+        if (_state.value.locationPermissionGranted) {
+            refreshWithLocation(isPullToRefresh = false)
+        } else {
+            loadRecommendations(isPullToRefresh = false)
+        }
+    }
+
+    private fun refreshWithLocation(isPullToRefresh: Boolean) {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            loadRecommendations()
+            loadRecommendations(isPullToRefresh = isPullToRefresh)
             return
         }
         viewModelScope.launch {
@@ -70,17 +81,25 @@ class RecommendationViewModel @Inject constructor(
             }
             loadRecommendations(
                 latitude = location?.latitude,
-                longitude = location?.longitude
+                longitude = location?.longitude,
+                isPullToRefresh = isPullToRefresh
             )
         }
     }
 
     private fun loadRecommendations(
         latitude: Double? = null,
-        longitude: Double? = null
+        longitude: Double? = null,
+        isPullToRefresh: Boolean = false
     ) {
         viewModelScope.launch {
-            _state.update { it.copy(isLoading = true, error = null) }
+            _state.update {
+                it.copy(
+                    isLoading = !isPullToRefresh,
+                    isRefreshing = isPullToRefresh,
+                    error = null
+                )
+            }
             val result = servicesRepository.getRecommendedServices(
                 page = 1,
                 limit = 5,
@@ -95,6 +114,8 @@ class RecommendationViewModel @Inject constructor(
                             recommendationMode = response.recommendationMode,
                             showProfilePrompt = response.showProfilePrompt,
                             isLoading = false,
+                            isRefreshing = false,
+                            hasLoadedOnce = true,
                             error = null
                         )
                     }
@@ -103,6 +124,8 @@ class RecommendationViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             isLoading = false,
+                            isRefreshing = false,
+                            hasLoadedOnce = true,
                             error = failure.message ?: "Failed to load recommendations"
                         )
                     }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/SavedServicesScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/SavedServicesScreen.kt
@@ -71,6 +71,7 @@ fun SavedServicesScreen(
             error = detailError,
             onBack = { selectedServiceId = null },
             viewModel = detailViewModel,
+            onOpenRecommendedService = { selectedServiceId = it },
             modifier = modifier
         )
         return

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailScreen.kt
@@ -644,40 +644,6 @@ fun ServiceDetailScreen(
                         }
                     }
 
-                    if (recommendedLoading || recommendedServices.isNotEmpty()) {
-                        DetailSection(title = "Services like this", icon = Icons.Default.TrendingUp) {
-                            if (recommendedLoading && recommendedServices.isEmpty()) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.Center
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(22.dp),
-                                        color = MaterialTheme.colorScheme.primary,
-                                        strokeWidth = 2.dp
-                                    )
-                                }
-                            } else {
-                                LazyRow(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                                ) {
-                                    items(
-                                        items = recommendedServices.take(3),
-                                        key = { it.service._id }
-                                    ) { item ->
-                                        RecommendedServiceCompactCard(
-                                            item = item,
-                                            onClick = {
-                                                onOpenRecommendedService?.invoke(item.service._id)
-                                            }
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
                     // Tags
                     if (service.tags.isNotEmpty()) {
                         DetailSection(title = "Tags", icon = Icons.Default.Tag) {
@@ -887,6 +853,39 @@ fun ServiceDetailScreen(
                                     .height(200.dp)
                                     .clip(RoundedCornerShape(8.dp))
                             )
+                        }
+                    }
+                    if (recommendedLoading || recommendedServices.isNotEmpty()) {
+                        DetailSection(title = "Services like this", icon = Icons.Default.TrendingUp) {
+                            if (recommendedLoading && recommendedServices.isEmpty()) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(22.dp),
+                                        color = MaterialTheme.colorScheme.primary,
+                                        strokeWidth = 2.dp
+                                    )
+                                }
+                            } else {
+                                LazyRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                ) {
+                                    items(
+                                        items = recommendedServices.take(3),
+                                        key = { it.service._id }
+                                    ) { item ->
+                                        RecommendedServiceCompactCard(
+                                            item = item,
+                                            onClick = {
+                                                onOpenRecommendedService?.invoke(item.service._id)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
                     // Clearance so the floating + FAB never overlaps the map

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailScreen.kt
@@ -90,6 +90,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.hive.hive_app.data.api.dto.BadgesResponse
 import com.hive.hive_app.data.api.dto.JoinRequestResponse
+import com.hive.hive_app.data.api.dto.RecommendedServiceItemDto
 import com.hive.hive_app.data.api.dto.ServiceResponse
 import com.hive.hive_app.data.api.dto.UserResponse
 import com.hive.hive_app.data.api.dto.CommentResponse
@@ -122,6 +123,7 @@ fun ServiceDetailScreen(
     isSaved: Boolean = false,
     onStartChat: ((String) -> Unit)? = null,
     onOpenUserProfile: ((String) -> Unit)? = null,
+    onOpenRecommendedService: ((String) -> Unit)? = null,
     /** Owner: open full-screen manage requests instead of a dialog. */
     onManageJoinRequests: (() -> Unit)? = null
 ) {
@@ -163,6 +165,10 @@ fun ServiceDetailScreen(
                 ?: remember { mutableStateOf(false) }
             val newCommentText by viewModel?.newCommentText?.collectAsState(initial = "")
                 ?: remember { mutableStateOf("") }
+            val recommendedServices by viewModel?.recommendedServices?.collectAsState(initial = emptyList())
+                ?: remember { mutableStateOf(emptyList<RecommendedServiceItemDto>()) }
+            val recommendedLoading by viewModel?.recommendedLoading?.collectAsState(initial = false)
+                ?: remember { mutableStateOf(false) }
             val focusManager = LocalFocusManager.current
             var showApplyDialog by remember { mutableStateOf(false) }
             var applyError by remember { mutableStateOf<String?>(null) }
@@ -638,6 +644,40 @@ fun ServiceDetailScreen(
                         }
                     }
 
+                    if (recommendedLoading || recommendedServices.isNotEmpty()) {
+                        DetailSection(title = "Services like this", icon = Icons.Default.TrendingUp) {
+                            if (recommendedLoading && recommendedServices.isEmpty()) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(22.dp),
+                                        color = MaterialTheme.colorScheme.primary,
+                                        strokeWidth = 2.dp
+                                    )
+                                }
+                            } else {
+                                LazyRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                ) {
+                                    items(
+                                        items = recommendedServices.take(3),
+                                        key = { it.service._id }
+                                    ) { item ->
+                                        RecommendedServiceCompactCard(
+                                            item = item,
+                                            onClick = {
+                                                onOpenRecommendedService?.invoke(item.service._id)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Tags
                     if (service.tags.isNotEmpty()) {
                         DetailSection(title = "Tags", icon = Icons.Default.Tag) {
@@ -854,6 +894,55 @@ fun ServiceDetailScreen(
                 }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun RecommendedServiceCompactCard(
+    item: RecommendedServiceItemDto,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val imageModel = buildImageRequest(context, item.service.imageUrls?.firstOrNull())
+    Card(
+        onClick = onClick,
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.size(width = 220.dp, height = 170.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (imageModel != null) {
+                AsyncImage(
+                    model = imageModel,
+                    contentDescription = item.service.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(82.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+            }
+            Text(
+                text = item.service.title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 2,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+            )
+            Text(
+                text = item.reason,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+            )
         }
     }
 }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ServiceDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.hive.hive_app.data.api.dto.BadgesResponse
 import com.hive.hive_app.data.api.dto.JoinRequestResponse
 import com.hive.hive_app.data.api.dto.CommentResponse
+import com.hive.hive_app.data.api.dto.RecommendedServiceItemDto
 import com.hive.hive_app.data.api.dto.RatingListResponse
 import com.hive.hive_app.data.api.dto.ServiceResponse
 import com.hive.hive_app.data.api.dto.UserResponse
@@ -82,6 +83,15 @@ class ServiceDetailViewModel @Inject constructor(
     private val _newCommentText = MutableStateFlow("")
     val newCommentText: StateFlow<String> = _newCommentText.asStateFlow()
 
+    private val _recommendedServices = MutableStateFlow<List<RecommendedServiceItemDto>>(emptyList())
+    val recommendedServices: StateFlow<List<RecommendedServiceItemDto>> = _recommendedServices.asStateFlow()
+
+    private val _recommendedLoading = MutableStateFlow(false)
+    val recommendedLoading: StateFlow<Boolean> = _recommendedLoading.asStateFlow()
+
+    private val _recommendedError = MutableStateFlow<String?>(null)
+    val recommendedError: StateFlow<String?> = _recommendedError.asStateFlow()
+
     fun load(serviceId: String) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -97,6 +107,9 @@ class ServiceDetailViewModel @Inject constructor(
             _commentsTotal.value = 0
             _commentsLoading.value = false
             _newCommentText.value = ""
+            _recommendedServices.value = emptyList()
+            _recommendedLoading.value = false
+            _recommendedError.value = null
             val currentUser = authRepository.getCurrentUser().getOrNull()
             servicesRepository.getService(serviceId).fold(
                 onSuccess = { service ->
@@ -122,10 +135,33 @@ class ServiceDetailViewModel @Inject constructor(
                     } else {
                         loadMyJoinRequestForService(serviceId)
                     }
+                    loadRecommendedServices(service)
                 },
                 onFailure = {
                     _error.value = it.message ?: "Failed to load"
                     _isLoading.value = false
+                }
+            )
+        }
+    }
+
+    private fun loadRecommendedServices(service: ServiceResponse) {
+        viewModelScope.launch {
+            _recommendedLoading.value = true
+            _recommendedError.value = null
+            servicesRepository.getRecommendedServices(page = 1, limit = 3).fold(
+                onSuccess = { response ->
+                    _recommendedServices.value = response.items
+                        .asSequence()
+                        .filter { it.service._id != service._id }
+                        .take(3)
+                        .toList()
+                    _recommendedLoading.value = false
+                },
+                onFailure = {
+                    _recommendedServices.value = emptyList()
+                    _recommendedError.value = it.message ?: "Failed to load recommendations"
+                    _recommendedLoading.value = false
                 }
             )
         }


### PR DESCRIPTION
Closes #358 

## Description

Adds a personalized recommendations experience to the Android app, mirroring the new `GET /services/recommendations` backend endpoint. Users now get tailored service suggestions based on their interests and (optionally) location, both as a dedicated page on the map and as a "Services like this" carousel on the service detail screen.

## Screenshots

(Add: Map screen with the new heart icon, the Recommendations page in personalized + empty states, and the "Services like this" section on a service detail.)


## Test Plan

1. **Map entry point**
   - Open the Map tab → tap the new heart icon in the control bar → verify the Recommendations page slides in and the icon switches to filled.
   - Tap back / system back → verify it returns to the map (and not directly out of the app).
   - Re-tap the Map bottom-tab while the recommendations page is open → verify the screen resets to the map root.
2. **Personalized vs. location fallback**
   - With location permission granted, open Recommendations → verify the header reads "Based on your interests and activity" or "Based on nearby opportunities" depending on `recommendation_mode`.
   - Revoke location permission and reopen → verify the call still succeeds (no lat/lng) and content still loads.
3. **Empty / error / loading states**
   - Sign in as a user with no interests/history → verify the empty state and the profile-prompt tip render.
   - Force an API failure (airplane mode) → verify the error state with Retry works.
   - Trigger pull-to-refresh and the header refresh icon → verify both refetch.
4. **Service detail carousel**
   - Open any service detail → verify "Services like this" appears with up to 3 cards (or is hidden if the API returns nothing).
   - Tap a card → verify it opens that service’s detail screen via the overlay stack from the Map, Discover, Active, and Saved entry points.
5. **Regression**
   - Confirm Discover, Active Items, and Saved Services still open service details normally.
   - Confirm `versionCode`/`versionName` bump appears in the built APK.