### PR TITLE
feat: allow moderators and admins to edit discussions and add image editing support

### DIFF
--- a/backend/app/api/forum.py
+++ b/backend/app/api/forum.py
@@ -75,7 +75,7 @@ async def update_discussion(
     db=Depends(get_database),
 ):
     svc = _forum(db)
-    is_admin = current_user.role == "admin"
+    is_admin = current_user.role in ("admin", "moderator")
     try:
         result = await svc.update_discussion(discussion_id, data, str(current_user.id), is_admin=is_admin)
         if not result:

--- a/backend/scripts/find_uncommented_items.py
+++ b/backend/scripts/find_uncommented_items.py
@@ -1,0 +1,103 @@
+"""
+Find forum discussions and events that have no comments.
+Usage: python scripts/find_uncommented_items.py [--mongo-url <url>] [--db <name>]
+"""
+
+import asyncio
+import sys
+import os
+import argparse
+from datetime import datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from bson import ObjectId
+
+
+async def find_uncommented_items(mongo_url: str, db_name: str):
+    client = AsyncIOMotorClient(mongo_url)
+    db = client[db_name]
+
+    # Collect all target_ids that have at least one comment, grouped by target_type
+    commented_ids: dict[str, set] = {"discussion": set(), "event": set()}
+
+    async for comment in db.forum_comments.find(
+        {"target_type": {"$in": ["discussion", "event"]}},
+        {"target_type": 1, "target_id": 1},
+    ):
+        t = comment.get("target_type")
+        if t in commented_ids:
+            commented_ids[t].add(str(comment["target_id"]))
+
+    # Find discussions without any comment
+    uncommented_discussions = []
+    async for doc in db.forum_discussions.find(
+        {}, {"_id": 1, "title": 1, "user_id": 1, "created_at": 1}
+    ):
+        if str(doc["_id"]) not in commented_ids["discussion"]:
+            uncommented_discussions.append(doc)
+
+    # Find events without any comment
+    uncommented_events = []
+    async for doc in db.forum_events.find(
+        {}, {"_id": 1, "title": 1, "user_id": 1, "created_at": 1, "event_at": 1}
+    ):
+        if str(doc["_id"]) not in commented_ids["event"]:
+            uncommented_events.append(doc)
+
+    client.close()
+    return uncommented_discussions, uncommented_events
+
+
+def fmt(doc: dict, extra_key: str | None = None) -> str:
+    created = doc.get("created_at", "")
+    if isinstance(created, datetime):
+        created = created.strftime("%Y-%m-%d %H:%M")
+    extra = ""
+    if extra_key and doc.get(extra_key):
+        val = doc[extra_key]
+        if isinstance(val, datetime):
+            val = val.strftime("%Y-%m-%d %H:%M")
+        extra = f"  {extra_key}: {val}"
+    return f"  [{doc['_id']}]  {doc.get('title', '(no title)')!r}  created: {created}{extra}"
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Find forum items with no comments")
+    parser.add_argument(
+        "--mongo-url",
+        default=os.getenv("MONGODB_URL", "mongodb://localhost:38017"),
+        help="MongoDB connection URL (default: mongodb://localhost:38017)",
+    )
+    parser.add_argument(
+        "--db",
+        default=os.getenv("DATABASE_NAME", "hive_platform"),
+        help="Database name (default: hive_platform)",
+    )
+    args = parser.parse_args()
+
+    print(f"Connecting to {args.mongo_url} / {args.db} …\n")
+
+    discussions, events = await find_uncommented_items(args.mongo_url, args.db)
+
+    print(f"=== Discussions with no comments ({len(discussions)}) ===")
+    if discussions:
+        for d in discussions:
+            print(fmt(d))
+    else:
+        print("  (none)")
+
+    print(f"\n=== Events with no comments ({len(events)}) ===")
+    if events:
+        for e in events:
+            print(fmt(e, extra_key="event_at"))
+    else:
+        print("  (none)")
+
+    total = len(discussions) + len(events)
+    print(f"\nTotal uncommented items: {total}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/src/pages/ForumDiscussionDetail.tsx
+++ b/frontend/src/pages/ForumDiscussionDetail.tsx
@@ -13,9 +13,9 @@ import {
   Box,
 } from "@radix-ui/themes";
 import { Form } from "radix-ui";
-import { ArrowLeftIcon, Pencil1Icon, TrashIcon } from "@radix-ui/react-icons";
+import { ArrowLeftIcon, Pencil1Icon, TrashIcon, PlusIcon } from "@radix-ui/react-icons";
 import { PinIcon } from "lucide-react";
-import { forumApi, getImageUrl, communityApi } from "@/services/api";
+import { forumApi, getImageUrl, uploadApi, communityApi } from "@/services/api";
 import { useUser } from "@/App";
 import { ForumDiscussion, TagEntity, Community } from "@/types";
 import { ClickableTag } from "@/components/ui/ClickableTag";
@@ -140,7 +140,7 @@ export function ForumDiscussionDetail() {
                     {discussion.is_pinned ? "Unpin" : "Pin"}
                   </Button>
                 )}
-                {isOwner && (
+                {(isOwner || canPinPlatform) && (
                   <>
                     <Button
                       variant="soft"
@@ -360,6 +360,8 @@ function EditDiscussionDialog({
   const [title, setTitle] = useState(discussion.title);
   const [body, setBody] = useState(discussion.body);
   const [tags, setTags] = useState<TagEntity[]>(discussion.tags ?? []);
+  const [imageUrls, setImageUrls] = useState<string[]>(discussion.image_urls ?? []);
+  const [imageUploading, setImageUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -368,6 +370,7 @@ function EditDiscussionDialog({
       setTitle(discussion.title);
       setBody(discussion.body);
       setTags(discussion.tags ?? []);
+      setImageUrls(discussion.image_urls ?? []);
       setError("");
     }
   }, [open, discussion]);
@@ -383,6 +386,7 @@ function EditDiscussionDialog({
         title,
         body,
         tags,
+        image_urls: imageUrls.length > 0 ? imageUrls : [],
       });
       onUpdated(res.data);
       onOpenChange(false);
@@ -433,6 +437,56 @@ function EditDiscussionDialog({
               }
             />
           </Form.Field>
+          <Box className="space-y-2">
+            <Text size="2" weight="medium" className="block">
+              Discussion image (optional)
+            </Text>
+            {imageUrls.length === 0 && (
+              <label className="cursor-pointer">
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  className="sr-only"
+                  disabled={imageUploading}
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    setImageUploading(true);
+                    try {
+                      const res = await uploadApi.uploadDiscussionImage(file);
+                      setImageUrls([res.data.url]);
+                    } catch {
+                      // ignore upload errors
+                    } finally {
+                      setImageUploading(false);
+                    }
+                  }}
+                />
+                <span className="flex items-center justify-center gap-2 border rounded-lg p-2 hover-card text-center cursor-pointer font-medium text-sm w-full">
+                  <PlusIcon className="w-4 h-4" />
+                  {imageUploading ? "Uploading..." : "Add image"}
+                </span>
+              </label>
+            )}
+            {imageUrls.length > 0 && (
+              <Flex gap="2" wrap="wrap" className="border rounded-lg p-2">
+                <Box className="relative">
+                  <img
+                    src={getImageUrl(imageUrls[0]) ?? imageUrls[0]}
+                    alt="Preview"
+                    className="w-20 h-20 object-cover rounded"
+                  />
+                  <button
+                    type="button"
+                    className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs"
+                    onClick={() => setImageUrls([])}
+                  >
+                    x
+                  </button>
+                </Box>
+              </Flex>
+            )}
+          </Box>
           {error && (
             <Text size="2" color="red">
               {error}
@@ -448,7 +502,7 @@ function EditDiscussionDialog({
               Cancel
             </Button>
             <Form.Submit asChild>
-              <Button type="submit" disabled={submitting}>
+              <Button type="submit" disabled={submitting || imageUploading}>
                 {submitting ? "Saving..." : "Save Changes"}
               </Button>
             </Form.Submit>


### PR DESCRIPTION
## Description

  - Moderators (previously only admins) can now edit and delete forum discussions via the backend. The `is_admin` flag
   in the update/delete endpoints now checks for both `admin` and `moderator` roles.
  - The Edit Discussion dialog now includes image upload/remove functionality, matching the create discussion form.
  Existing images are pre-loaded when the dialog opens.

  Changes:
  - `backend/app/api/forum.py`: `is_admin = current_user.role in ("admin", "moderator")` for `update_discussion`
  - `frontend/src/pages/ForumDiscussionDetail.tsx`: Edit/Delete buttons visible to moderators and admins; image upload
   added to edit form

  ## Screenshots
<img width="1098" height="846" alt="Screenshot 2026-05-11 at 09 34 50" src="https://github.com/user-attachments/assets/4f065c63-61f9-451b-8046-f8ff3e396444" />


  ## Test Plan

  1. Log in as a moderator
  2. Open any forum discussion you don't own
  3. Verify Edit and Delete buttons are visible
  4. Click Edit → confirm image upload/remove works
  5. Save → verify changes persist including image
  6. Log in as a regular user → confirm Edit/Delete not visible on others' discussions