### PR TITLE
test: adding mobile unit tests

### DIFF
--- a/app/app/src/test/java/com/hive/hive_app/data/api/dto/MoshiDtoTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/data/api/dto/MoshiDtoTest.kt
@@ -1,0 +1,181 @@
+package com.hive.hive_app.data.api.dto
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MoshiDtoTest {
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    @Test
+    fun parsesTagDtoBackendAndLegacyIdentityFields() {
+        val adapter = moshi.adapter(TagDto::class.java)
+
+        val tag = adapter.fromJson(
+            """
+            {
+              "entityId": "Q638",
+              "id": "legacy-id",
+              "label": "Music",
+              "description": "art form"
+            }
+            """.trimIndent()
+        )
+
+        assertEquals("Q638", tag?.entityId)
+        assertEquals("legacy-id", tag?.id)
+        assertEquals("Music", tag?.label)
+        assertEquals("art form", tag?.description)
+    }
+
+    @Test
+    fun serializesServiceCreateWithBackendFieldNames() {
+        val adapter = moshi.adapter(ServiceCreate::class.java)
+        val json = adapter.toJson(
+            ServiceCreate(
+                title = "Guitar lesson",
+                description = "Beginner lesson",
+                tags = listOf(TagDto(entityId = "Q638", label = "Music")),
+                estimatedDuration = 2.5,
+                location = LocationDto(latitude = 41.0, longitude = 29.0, address = "Kadikoy"),
+                city = "Istanbul",
+                serviceType = "offer",
+                maxParticipants = 3,
+                schedulingType = "specific",
+                specificDate = "2026-06-01",
+                specificTime = "10:00",
+                imageUrls = listOf("image.jpg"),
+                isRemote = true
+            )
+        )
+
+        assertTrue(json.contains("\"estimated_duration\":2.5"))
+        assertTrue(json.contains("\"service_type\":\"offer\""))
+        assertTrue(json.contains("\"max_participants\":3"))
+        assertTrue(json.contains("\"scheduling_type\":\"specific\""))
+        assertTrue(json.contains("\"specific_date\":\"2026-06-01\""))
+        assertTrue(json.contains("\"specific_time\":\"10:00\""))
+        assertTrue(json.contains("\"image_urls\":[\"image.jpg\"]"))
+        assertTrue(json.contains("\"is_remote\":true"))
+        assertTrue(json.contains("\"entityId\":\"Q638\""))
+        assertFalse(json.contains("\"estimatedDuration\""))
+        assertFalse(json.contains("\"serviceType\""))
+    }
+
+    @Test
+    fun parsesServiceResponseFromBackendFieldNames() {
+        val adapter = moshi.adapter(ServiceResponse::class.java)
+
+        val service = adapter.fromJson(
+            """
+            {
+              "_id": "service-1",
+              "title": "Guitar lesson",
+              "description": "Beginner lesson",
+              "tags": [],
+              "estimated_duration": 1.5,
+              "location": { "latitude": 41.0, "longitude": 29.0, "address": "Kadikoy" },
+              "service_type": "need",
+              "max_participants": 2,
+              "user_id": "user-1",
+              "status": "active",
+              "is_pinned": true,
+              "created_at": "2026-01-01T00:00:00",
+              "updated_at": "2026-01-02T00:00:00",
+              "scheduling_type": "open",
+              "open_availability": "Weekends",
+              "image_urls": ["one.jpg", "two.jpg"],
+              "is_remote": false
+            }
+            """.trimIndent()
+        )
+
+        assertEquals("service-1", service?.`_id`)
+        assertEquals(1.5, service?.estimatedDuration ?: 0.0, 0.0)
+        assertEquals("need", service?.serviceType)
+        assertEquals(2, service?.maxParticipants)
+        assertEquals("user-1", service?.userId)
+        assertEquals(true, service?.isPinned)
+        assertEquals("open", service?.schedulingType)
+        assertEquals("Weekends", service?.openAvailability)
+        assertEquals(listOf("one.jpg", "two.jpg"), service?.imageUrls)
+        assertEquals(false, service?.isRemote)
+    }
+
+    @Test
+    fun parsesForumEventResponseFromBackendFieldNames() {
+        val adapter = moshi.adapter(ForumEventResponse::class.java)
+
+        val event = adapter.fromJson(
+            """
+            {
+              "_id": "event-1",
+              "user_id": "user-1",
+              "title": "Neighborhood Jam",
+              "description": "Bring an instrument",
+              "event_at": "2026-06-01T15:30:00",
+              "community_id": "community-1",
+              "location": "Kadikoy",
+              "latitude": 40.99,
+              "longitude": 29.03,
+              "is_remote": false,
+              "tags": [{ "entityId": "Q638", "label": "Music" }],
+              "service_id": "service-1",
+              "image_urls": ["event.jpg"],
+              "banner_image_url": "banner.jpg",
+              "created_at": "2026-05-01T00:00:00",
+              "updated_at": "2026-05-02T00:00:00",
+              "comment_count": 4,
+              "attendee_ids": ["user-2"],
+              "attendee_count": 1,
+              "is_pinned": true
+            }
+            """.trimIndent()
+        )
+
+        assertEquals("event-1", event?.id)
+        assertEquals("user-1", event?.userId)
+        assertEquals("2026-06-01T15:30:00", event?.eventAt)
+        assertEquals("community-1", event?.communityId)
+        assertEquals("service-1", event?.serviceId)
+        assertEquals(listOf("event.jpg"), event?.imageUrls)
+        assertEquals("banner.jpg", event?.bannerImageUrl)
+        assertEquals(4, event?.commentCount)
+        assertEquals(listOf("user-2"), event?.attendeeIds)
+        assertEquals(1, event?.attendeeCount)
+        assertEquals(true, event?.isPinned)
+    }
+
+    @Test
+    fun parsesNotificationResponseFromBackendFieldNames() {
+        val adapter = moshi.adapter(NotificationResponse::class.java)
+
+        val notification = adapter.fromJson(
+            """
+            {
+              "_id": "notification-1",
+              "user_id": "user-1",
+              "type": "comment",
+              "title": "New comment",
+              "body": "Someone replied",
+              "related_id": "discussion-1",
+              "related_type": "discussion",
+              "is_read": true,
+              "created_at": "2026-05-01T10:00:00"
+            }
+            """.trimIndent()
+        )
+
+        assertEquals("notification-1", notification?.id)
+        assertEquals("user-1", notification?.userId)
+        assertEquals("discussion-1", notification?.relatedId)
+        assertEquals("discussion", notification?.relatedType)
+        assertEquals(true, notification?.isRead)
+        assertEquals("2026-05-01T10:00:00", notification?.createdAt)
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/data/repository/CommunityRepositoryTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/data/repository/CommunityRepositoryTest.kt
@@ -1,0 +1,155 @@
+package com.hive.hive_app.data.repository
+
+import com.hive.hive_app.data.api.CommunityApi
+import com.hive.hive_app.data.api.dto.CommunityCreate
+import com.hive.hive_app.data.api.dto.CommunityListResponse
+import com.hive.hive_app.data.api.dto.CommunityMemberListResponse
+import com.hive.hive_app.data.api.dto.CommunityMemberResponse
+import com.hive.hive_app.data.api.dto.CommunityPostCreate
+import com.hive.hive_app.data.api.dto.CommunityPostListResponse
+import com.hive.hive_app.data.api.dto.CommunityPostResponse
+import com.hive.hive_app.data.api.dto.CommunityResponse
+import com.hive.hive_app.data.api.dto.ForumUserEmbed
+import com.hive.hive_app.data.api.dto.UpvoteResponse
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+class CommunityRepositoryTest {
+    @Test
+    fun getCommunityMembersMapsNestedUsersAndFiltersMissingUsers() = runBlocking {
+        val alice = ForumUserEmbed(id = "user-1", username = "alice", fullName = "Alice")
+        val api = FakeCommunityApi(
+            membersResponse = Response.success(
+                CommunityMemberListResponse(
+                    members = listOf(
+                        member("member-1", alice),
+                        member("member-2", user = null)
+                    ),
+                    total = 2
+                )
+            )
+        )
+        val repository = CommunityRepository(api)
+
+        val result = repository.getCommunityMembers("community-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf(alice), result.getOrThrow())
+        assertEquals("community-1", api.lastMembersCommunityId)
+    }
+
+    @Test
+    fun getCommunityMembersReturnsEmptyListWhenBodyIsMissing() = runBlocking {
+        val api = FakeCommunityApi(membersResponse = Response.success(null))
+        val repository = CommunityRepository(api)
+
+        val result = repository.getCommunityMembers("community-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<ForumUserEmbed>(), result.getOrThrow())
+    }
+
+    @Test
+    fun getCommunityMembersReturnsFailureForHttpError() = runBlocking {
+        val api = FakeCommunityApi(membersResponse = errorResponse())
+        val repository = CommunityRepository(api)
+
+        val result = repository.getCommunityMembers("community-1")
+
+        assertTrue(result.isFailure)
+    }
+
+    private class FakeCommunityApi(
+        private val membersResponse: Response<CommunityMemberListResponse> = Response.success(
+            CommunityMemberListResponse()
+        )
+    ) : CommunityApi {
+        var lastMembersCommunityId: String? = null
+
+        override suspend fun getCommunityMembers(
+            communityId: String
+        ): Response<CommunityMemberListResponse> {
+            lastMembersCommunityId = communityId
+            return membersResponse
+        }
+
+        override suspend fun listCommunities(
+            page: Int,
+            limit: Int,
+            q: String?,
+            sortBy: String?,
+            myOnly: Boolean?
+        ): Response<CommunityListResponse> = unused()
+
+        override suspend fun createCommunity(
+            body: CommunityCreate
+        ): Response<CommunityResponse> = unused()
+
+        override suspend fun getCommunity(
+            communityId: String
+        ): Response<CommunityResponse> = unused()
+
+        override suspend fun pinCommunity(
+            communityId: String,
+            pinned: Boolean
+        ): Response<CommunityResponse> = unused()
+
+        override suspend fun joinCommunity(
+            communityId: String
+        ): Response<CommunityResponse> = unused()
+
+        override suspend fun leaveCommunity(
+            communityId: String
+        ): Response<CommunityResponse> = unused()
+
+        override suspend fun getCommunityPosts(
+            communityId: String,
+            page: Int,
+            limit: Int,
+            sortBy: String?
+        ): Response<CommunityPostListResponse> = unused()
+
+        override suspend fun createCommunityPost(
+            communityId: String,
+            body: CommunityPostCreate
+        ): Response<CommunityPostResponse> = unused()
+
+        override suspend fun upvotePost(
+            communityId: String,
+            postId: String
+        ): Response<UpvoteResponse> = unused()
+
+        override suspend fun pinPost(
+            communityId: String,
+            postId: String,
+            pinned: Boolean
+        ): Response<CommunityPostResponse> = unused()
+
+        private fun <T> unused(): Response<T> {
+            throw UnsupportedOperationException("Unused in this test")
+        }
+    }
+
+    companion object {
+        private fun member(
+            id: String,
+            user: ForumUserEmbed?
+        ) = CommunityMemberResponse(
+            id = id,
+            communityId = "community-1",
+            userId = user?.resolvedId ?: "missing-user",
+            user = user
+        )
+
+        private fun <T> errorResponse(): Response<T> =
+            Response.error(
+                500,
+                """{"detail":"server error"}""".toResponseBody("application/json".toMediaType())
+            )
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/data/repository/NotificationsRepositoryTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/data/repository/NotificationsRepositoryTest.kt
@@ -1,0 +1,157 @@
+package com.hive.hive_app.data.repository
+
+import com.hive.hive_app.data.api.NotificationsApi
+import com.hive.hive_app.data.api.dto.NotificationListResponse
+import com.hive.hive_app.data.api.dto.NotificationResponse
+import com.hive.hive_app.data.api.dto.UnreadCountResponse
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+class NotificationsRepositoryTest {
+    @Test
+    fun getNotificationsWrapsSuccessfulResponse() = runBlocking {
+        val notification = notification(id = "notification-1")
+        val api = FakeNotificationsApi(
+            notificationsResponse = Response.success(
+                NotificationListResponse(
+                    notifications = listOf(notification),
+                    total = 1,
+                    page = 2,
+                    limit = 10
+                )
+            )
+        )
+        val repository = NotificationsRepository(api)
+
+        val result = repository.getNotifications(page = 2, limit = 10)
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf(notification), result.getOrThrow().notifications)
+        assertEquals(2, api.lastPage)
+        assertEquals(10, api.lastLimit)
+    }
+
+    @Test
+    fun getNotificationsReturnsFailureForHttpError() = runBlocking {
+        val api = FakeNotificationsApi(
+            notificationsResponse = errorResponse()
+        )
+        val repository = NotificationsRepository(api)
+
+        val result = repository.getNotifications()
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun getUnreadCountWrapsSuccessfulResponse() = runBlocking {
+        val api = FakeNotificationsApi(
+            unreadCountResponse = Response.success(UnreadCountResponse(count = 4))
+        )
+        val repository = NotificationsRepository(api)
+
+        val result = repository.getUnreadCount()
+
+        assertTrue(result.isSuccess)
+        assertEquals(4, result.getOrThrow().count)
+    }
+
+    @Test
+    fun markReadWrapsSuccessfulResponseAndRecordsId() = runBlocking {
+        val readNotification = notification(id = "notification-2", isRead = true)
+        val api = FakeNotificationsApi(
+            markReadResponse = Response.success(readNotification)
+        )
+        val repository = NotificationsRepository(api)
+
+        val result = repository.markRead("notification-2")
+
+        assertTrue(result.isSuccess)
+        assertEquals(readNotification, result.getOrThrow())
+        assertEquals("notification-2", api.lastMarkReadId)
+    }
+
+    @Test
+    fun markAllReadReturnsSuccessForSuccessfulEmptyResponse() = runBlocking {
+        val api = FakeNotificationsApi(markAllReadResponse = Response.success(Unit))
+        val repository = NotificationsRepository(api)
+
+        val result = repository.markAllRead()
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun markAllReadReturnsFailureForHttpError() = runBlocking {
+        val api = FakeNotificationsApi(markAllReadResponse = errorResponse())
+        val repository = NotificationsRepository(api)
+
+        val result = repository.markAllRead()
+
+        assertTrue(result.isFailure)
+    }
+
+    private class FakeNotificationsApi(
+        private val notificationsResponse: Response<NotificationListResponse> = Response.success(
+            NotificationListResponse(emptyList(), total = 0, page = 1, limit = 20)
+        ),
+        private val unreadCountResponse: Response<UnreadCountResponse> = Response.success(
+            UnreadCountResponse(count = 0)
+        ),
+        private val markReadResponse: Response<NotificationResponse> = Response.success(
+            notification()
+        ),
+        private val markAllReadResponse: Response<Unit> = Response.success(Unit)
+    ) : NotificationsApi {
+        var lastPage: Int? = null
+        var lastLimit: Int? = null
+        var lastMarkReadId: String? = null
+
+        override suspend fun getNotifications(
+            page: Int,
+            limit: Int
+        ): Response<NotificationListResponse> {
+            lastPage = page
+            lastLimit = limit
+            return notificationsResponse
+        }
+
+        override suspend fun getUnreadCount(): Response<UnreadCountResponse> =
+            unreadCountResponse
+
+        override suspend fun markRead(id: String): Response<NotificationResponse> {
+            lastMarkReadId = id
+            return markReadResponse
+        }
+
+        override suspend fun markAllRead(): Response<Unit> = markAllReadResponse
+    }
+
+    companion object {
+        private fun notification(
+            id: String = "notification-1",
+            isRead: Boolean = false
+        ) = NotificationResponse(
+            id = id,
+            userId = "user-1",
+            type = "message",
+            title = "New message",
+            body = "Alice sent you a message",
+            relatedId = "chat-1",
+            relatedType = "chat",
+            isRead = isRead,
+            createdAt = "2026-05-01T10:00:00"
+        )
+
+        private fun <T> errorResponse(): Response<T> =
+            Response.error(
+                500,
+                """{"detail":"server error"}""".toResponseBody("application/json".toMediaType())
+            )
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/data/repository/WikidataRepositoryTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/data/repository/WikidataRepositoryTest.kt
@@ -1,0 +1,84 @@
+package com.hive.hive_app.data.repository
+
+import com.hive.hive_app.data.api.WikidataApi
+import com.hive.hive_app.data.api.dto.WikidataSearchResponse
+import com.hive.hive_app.data.api.dto.WikidataSearchResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WikidataRepositoryTest {
+    @Test
+    fun searchTagsStripsHtmlAndUsesTitleAsId() = runBlocking {
+        val api = FakeWikidataApi(
+            response = WikidataSearchResponse(
+                results = listOf(
+                    WikidataSearchResult(
+                        title = "Q638",
+                        titleSnippet = "<span class=\"searchmatch\">Music</span>&nbsp;genre"
+                    )
+                )
+            )
+        )
+        val repository = WikidataRepository(api)
+
+        val result = repository.searchTags(query = "music", language = "en", limit = 5)
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf(WikidataTagSuggestion("Q638", "Music genre")), result.getOrThrow())
+        assertEquals("music", api.lastQuery)
+        assertEquals("en", api.lastLanguage)
+        assertEquals(5, api.lastLimit)
+    }
+
+    @Test
+    fun searchTagsFallsBackToPageIdAndDropsItemsWithoutIdentity() = runBlocking {
+        val api = FakeWikidataApi(
+            response = WikidataSearchResponse(
+                results = listOf(
+                    WikidataSearchResult(pageId = "123", titleSnippet = ""),
+                    WikidataSearchResult(title = "", pageId = "")
+                )
+            )
+        )
+        val repository = WikidataRepository(api)
+
+        val result = repository.searchTags(query = "garden")
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf(WikidataTagSuggestion("123", "123")), result.getOrThrow())
+    }
+
+    @Test
+    fun searchTagsReturnsFailureWhenApiThrows() = runBlocking {
+        val api = FakeWikidataApi(error = IllegalStateException("network down"))
+        val repository = WikidataRepository(api)
+
+        val result = repository.searchTags(query = "music")
+
+        assertTrue(result.isFailure)
+        assertEquals("network down", result.exceptionOrNull()?.message)
+    }
+
+    private class FakeWikidataApi(
+        private val response: WikidataSearchResponse = WikidataSearchResponse(),
+        private val error: Throwable? = null
+    ) : WikidataApi {
+        var lastQuery: String? = null
+        var lastLanguage: String? = null
+        var lastLimit: Int? = null
+
+        override suspend fun search(
+            query: String,
+            language: String,
+            limit: Int
+        ): WikidataSearchResponse {
+            lastQuery = query
+            lastLanguage = language
+            lastLimit = limit
+            error?.let { throw it }
+            return response
+        }
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/ui/main/CompleteServiceRatingArgsTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/ui/main/CompleteServiceRatingArgsTest.kt
@@ -1,0 +1,23 @@
+package com.hive.hive_app.ui.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompleteServiceRatingArgsTest {
+    @Test
+    fun storesCompletionRatingNavigationPayload() {
+        val args = CompleteServiceRatingArgs(
+            transactionId = "txn-1",
+            serviceTitle = "Guitar lesson",
+            otherName = "Alice",
+            creditsHours = 2.5,
+            ratedUserId = "user-2"
+        )
+
+        assertEquals("txn-1", args.transactionId)
+        assertEquals("Guitar lesson", args.serviceTitle)
+        assertEquals("Alice", args.otherName)
+        assertEquals(2.5, args.creditsHours, 0.0)
+        assertEquals("user-2", args.ratedUserId)
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/util/BadgeIconUtilsTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/util/BadgeIconUtilsTest.kt
@@ -1,0 +1,36 @@
+package com.hive.hive_app.util
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Label
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Stars
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BadgeIconUtilsTest {
+    @Test
+    fun mapsKnownBadgeKeysToExpectedIcons() {
+        assertEquals(Icons.Filled.Person.name, badgeIcon("newcomer").name)
+        assertEquals(Icons.Filled.Label.name, badgeIcon("tagged").name)
+        assertEquals(Icons.Filled.Favorite.name, badgeIcon("community_favorite").name)
+        assertEquals(Icons.Filled.Group.name, badgeIcon("cross_pollinator").name)
+        assertEquals(Icons.Filled.Stars.name, badgeIcon("true_bee").name)
+    }
+
+    @Test
+    fun mapsRelatedHelperBadgesToSchoolIcon() {
+        assertEquals(Icons.Filled.School.name, badgeIcon("helper").name)
+        assertEquals(Icons.Filled.School.name, badgeIcon("helper_hero").name)
+        assertEquals(Icons.Filled.School.name, badgeIcon("master_helper").name)
+    }
+
+    @Test
+    fun fallsBackToStarForUnknownOrMissingBadgeKeys() {
+        assertEquals(Icons.Filled.Star.name, badgeIcon("unknown_badge").name)
+        assertEquals(Icons.Filled.Star.name, badgeIcon(null).name)
+    }
+}

--- a/app/app/src/test/java/com/hive/hive_app/util/BadgeUtilsTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/util/BadgeUtilsTest.kt
@@ -1,0 +1,53 @@
+package com.hive.hive_app.util
+
+import com.hive.hive_app.data.api.dto.BadgeEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BadgeUtilsTest {
+    @Test
+    fun returnsHighestPriorityEarnedBadgeInsteadOfFirstBadge() {
+        val badges = listOf(
+            badge("newcomer", earned = true),
+            badge("true_bee", earned = true),
+            badge("helper", earned = true)
+        )
+
+        assertEquals("true_bee", getHighestPriorityBadge(badges)?.key)
+    }
+
+    @Test
+    fun ignoresHighPriorityBadgesThatAreNotEarned() {
+        val badges = listOf(
+            badge("true_bee", earned = false),
+            badge("helper_hero", earned = true),
+            badge("newcomer", earned = true)
+        )
+
+        assertEquals("helper_hero", getHighestPriorityBadge(badges)?.key)
+    }
+
+    @Test
+    fun fallsBackToFirstEarnedBadgeWhenNoKnownPriorityKeyMatches() {
+        val badges = listOf(
+            badge("custom_badge", earned = true),
+            badge("another_custom_badge", earned = true)
+        )
+
+        assertEquals("custom_badge", getHighestPriorityBadge(badges)?.key)
+    }
+
+    @Test
+    fun returnsNullWhenBadgesAreMissingOrNoneAreEarned() {
+        assertNull(getHighestPriorityBadge(null))
+        assertNull(getHighestPriorityBadge(emptyList()))
+        assertNull(getHighestPriorityBadge(listOf(badge("true_bee", earned = false))))
+    }
+
+    private fun badge(key: String, earned: Boolean) = BadgeEntry(
+        key = key,
+        name = key,
+        earned = earned
+    )
+}

--- a/app/app/src/test/java/com/hive/hive_app/util/FormatUtilsTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/util/FormatUtilsTest.kt
@@ -1,0 +1,114 @@
+package com.hive.hive_app.util
+
+import com.hive.hive_app.data.api.dto.LocationDto
+import com.hive.hive_app.data.api.dto.ServiceResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+
+class FormatUtilsTest {
+    @Test
+    fun formatsDurationHoursAsRoundedWholeHours() {
+        assertEquals("1h", formatDurationHours(1.2))
+        assertEquals("2h", formatDurationHours(1.5))
+        assertEquals("3h", formatDurationHours(2.6))
+    }
+
+    @Test
+    fun formatsApplicationDatesAndFallsBackForInvalidInput() {
+        assertEquals("Apr 27, 2026", formatApplicationDate("2026-04-27T10:00:00"))
+        assertEquals("Apr 27, 2026", formatApplicationDate("2026-04-27"))
+        assertEquals("", formatApplicationDate(null))
+        assertEquals("not-a-date", formatApplicationDate("not-a-date"))
+    }
+
+    @Test
+    fun formatsApplicationDateTimeAndFallsBackToDateOnly() {
+        assertEquals(
+            "Apr 27, 2026 \u00b7 10:30 AM",
+            formatApplicationDateTime("2026-04-27T10:30:00")
+        )
+        assertEquals("Apr 27, 2026", formatApplicationDateTime("2026-04-27"))
+        assertEquals("", formatApplicationDateTime(""))
+    }
+
+    @Test
+    fun formatsOrdinalDatesWithCorrectSuffixes() {
+        assertEquals("1st of January 2026", formatLongOrdinalDate("2026-01-01"))
+        assertEquals("2nd of January 2026", formatLongOrdinalDate("2026-01-02"))
+        assertEquals("3rd of January 2026", formatLongOrdinalDate("2026-01-03"))
+        assertEquals("11th of January 2026", formatLongOrdinalDate("2026-01-11"))
+        assertEquals("23rd of January 2026", formatLongOrdinalDate("2026-01-23"))
+        assertEquals("", formatLongOrdinalDate("bad-date"))
+    }
+
+    @Test
+    fun formatsMemberJoinDateAndMembershipDurationEdgeCases() {
+        assertEquals("February 21st, 2026", formatMemberJoinDate("2026-02-21T08:00:00"))
+        assertEquals("", formatMemberJoinDate(null))
+        assertEquals("", formatMemberJoinDate("bad-date"))
+
+        assertEquals("", formatMemberSinceDuration(null))
+        assertEquals("", formatMemberSinceDuration("bad-date"))
+        assertEquals("", formatMemberSinceDuration(LocalDate.now().plusDays(1).toString()))
+        assertEquals("today", formatMemberSinceDuration(LocalDate.now().toString()))
+    }
+
+    @Test
+    fun formatsRawDatesForDisplayOnlyWhenPresent() {
+        assertEquals("Apr 27, 2026", formatRawDateForDisplay("2026-04-27"))
+        assertEquals("Apr 27, 2026", formatRawDateForDisplay("2026-04-27T10:00:00"))
+        assertEquals("not-a-date", formatRawDateForDisplay("not-a-date"))
+        assertNull(formatRawDateForDisplay(null))
+        assertNull(formatRawDateForDisplay("   "))
+    }
+
+    @Test
+    fun formatsServiceSchedulingDisplayFromSpecificOrOpenAvailability() {
+        assertEquals(
+            "Apr 27, 2026 at 10:00",
+            formatServiceSchedulingDisplay(
+                service(specificDate = "2026-04-27", specificTime = "10:00")
+            )
+        )
+        assertEquals(
+            "Apr 27, 2026",
+            formatServiceSchedulingDisplay(service(specificDate = "2026-04-27"))
+        )
+        assertEquals(
+            "Open Availability - Weekends",
+            formatServiceSchedulingDisplay(service(openAvailability = "Weekends"))
+        )
+        assertEquals(
+            "Open Availability - Flexible mornings",
+            formatServiceSchedulingDisplay(
+                service(schedulingType = "open", description = "Flexible mornings")
+            )
+        )
+        assertNull(formatServiceSchedulingDisplay(service()))
+    }
+
+    private fun service(
+        description: String = "",
+        schedulingType: String? = null,
+        specificDate: String? = null,
+        specificTime: String? = null,
+        openAvailability: String? = null
+    ) = ServiceResponse(
+        _id = "service-1",
+        title = "Guitar lesson",
+        description = description,
+        tags = emptyList(),
+        estimatedDuration = 1.0,
+        location = LocationDto(latitude = 41.0, longitude = 29.0),
+        serviceType = "offer",
+        userId = "user-1",
+        createdAt = "2026-01-01T00:00:00",
+        updatedAt = "2026-01-01T00:00:00",
+        schedulingType = schedulingType,
+        specificDate = specificDate,
+        specificTime = specificTime,
+        openAvailability = openAvailability
+    )
+}


### PR DESCRIPTION
## Description

Added Android local unit tests for mobile-side utility, DTO, and repository behavior. These tests run on the JVM and do not require an emulator.

- Summary of changes
  - Replaced the default `ExampleUnitTest` dummy test with real Android unit tests
  - Added tests for date/scheduling formatting helpers
  - Added tests for badge priority and badge icon mapping
  - Added tests for completion rating argument payloads
  - Added repository tests for Wikidata, notifications, and community member mapping
  - Added Moshi DTO tests for backend JSON field mappings

- Reasoning
  - Mobile had only the default sample unit test, so this improves Android-side test coverage with meaningful, emulator-free tests.
  - The tests focus on pure logic, repository response handling, and API DTO serialization/deserialization.

- Additional context
  - No Android UI/instrumented tests were added.
  - No emulator is required.
  - `app/local.properties` is local-only and should not be committed.


## Test Plan

Run Android local unit tests:

```bash
cd app
./gradlew testDebugUnitTest


## Results

BUILD SUCCESSFUL
32 Android local unit tests passed
