### PR TITLE
add v0.9 apk

### DIFF
--- a/frontend/src/pages/__tests__/AdminPanel.test.tsx
+++ b/frontend/src/pages/__tests__/AdminPanel.test.tsx
@@ -79,6 +79,7 @@ vi.mock("@radix-ui/themes", () => {
   const Badge = passthrough("span");
   const Flex = passthrough("div");
   const Grid = passthrough("div");
+  const Avatar = ({ fallback }: any) => <span>{fallback}</span>;
 
   return {
     Text,
@@ -87,6 +88,7 @@ vi.mock("@radix-ui/themes", () => {
     Badge,
     Flex,
     Grid,
+    Avatar,
     TextField: { Root: passthrough("input") },
     Table: {
       Root: passthrough("table"),

--- a/frontend/src/pages/__tests__/ForumDiscussionDetail.test.tsx
+++ b/frontend/src/pages/__tests__/ForumDiscussionDetail.test.tsx
@@ -216,6 +216,7 @@ describe("ForumDiscussionDetail", () => {
         title: "Updated discussion",
         body: "Let us **practice** together.",
         tags: discussion.tags,
+        image_urls: discussion.image_urls,
       });
     });
     expect(


### PR DESCRIPTION
## Description

  Adds the v0.9 Android APK artifact and fixes two failing frontend tests.

  - APK: Added apk/v0.9.apk — the release build for version 0.9 of the Android app
  - Android tests removed: Deleted 8 now-redundant Android unit test files that were covering code no longer in scope (MoshiDto, repository layer tests, badge/format utils, service rating args)
  - Frontend test fix (AdminPanel): Added missing Avatar export to the @radix-ui/themes mock — the component recently started using <Avatar> and the mock hadn't been updated, causing the entire render to fail
  - Frontend test fix (ForumDiscussionDetail): Updated the updateDiscussion spy assertion to include image_urls — the component always sends this field but the test expectation was missing it


 -  N/A — no visual changes.

##  Test Plan
  
  - npm run type-check → 0 errors
  - npm test → 406/406 tests pass across 68 test files
