### PR TITLE
Add community events to the community screen in mobile

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.hive.hive_app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "1.1.14"
+        versionCode = 15
+        versionName = "1.1.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BASE_URL", "\"https://backend-swe.gnahh5.easypanel.host\"")

--- a/app/app/src/main/java/com/hive/hive_app/data/api/CommunityApi.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/api/CommunityApi.kt
@@ -7,6 +7,7 @@ import com.hive.hive_app.data.api.dto.CommunityPostListResponse
 import com.hive.hive_app.data.api.dto.CommunityPostResponse
 import com.hive.hive_app.data.api.dto.CommunityResponse
 import com.hive.hive_app.data.api.dto.CommunityMemberListResponse
+import com.hive.hive_app.data.api.dto.ForumEventListResponse
 import com.hive.hive_app.data.api.dto.UpvoteResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -77,4 +78,9 @@ interface CommunityApi {
     suspend fun getCommunityMembers(
         @Path("community_id") communityId: String
     ): Response<CommunityMemberListResponse>
+
+    @GET("communities/{community_id}/events")
+    suspend fun getCommunityEvents(
+        @Path("community_id") communityId: String
+    ): Response<ForumEventListResponse>
 }

--- a/app/app/src/main/java/com/hive/hive_app/data/repository/CommunityRepository.kt
+++ b/app/app/src/main/java/com/hive/hive_app/data/repository/CommunityRepository.kt
@@ -7,6 +7,7 @@ import com.hive.hive_app.data.api.dto.CommunityPostCreate
 import com.hive.hive_app.data.api.dto.CommunityPostListResponse
 import com.hive.hive_app.data.api.dto.CommunityPostResponse
 import com.hive.hive_app.data.api.dto.CommunityResponse
+import com.hive.hive_app.data.api.dto.ForumEventListResponse
 import com.hive.hive_app.data.api.dto.ForumUserEmbed
 import com.hive.hive_app.data.api.dto.UpvoteResponse
 import retrofit2.HttpException
@@ -86,5 +87,10 @@ class CommunityRepository @Inject constructor(
         if (!resp.isSuccessful) throw HttpException(resp)
         val body = resp.body()
         body?.members?.mapNotNull { it.user } ?: emptyList()
+    }
+
+    suspend fun getCommunityEvents(communityId: String): Result<ForumEventListResponse> = runCatching {
+        val resp = communityApi.getCommunityEvents(communityId)
+        if (resp.isSuccessful) resp.body()!! else throw HttpException(resp)
     }
 }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ForumScreen.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ForumScreen.kt
@@ -171,6 +171,11 @@ fun ForumScreen(
                 viewModel.clearEventDetail()
                 selectedEventId = null
             },
+            onOpenCommunity = { communityId ->
+                viewModel.clearEventDetail()
+                selectedEventId = null
+                selectedCommunityId = communityId
+            },
             onOpenUserProfile = onOpenUserProfile,
             modifier = modifier,
             bottomBarPadding = bottomBarPadding
@@ -180,7 +185,10 @@ fun ForumScreen(
 
     if (selectedCommunityId != null) {
         val id = selectedCommunityId!!
-        LaunchedEffect(id) { viewModel.loadCommunityDetail(id) }
+        LaunchedEffect(id) {
+            viewModel.loadCommunityDetail(id)
+            viewModel.loadCommunityEvents(id)
+        }
         CommunityDetailScreen(
             communityId = id,
             viewModel = viewModel,
@@ -188,6 +196,7 @@ fun ForumScreen(
                 viewModel.clearCommunityDetail()
                 selectedCommunityId = null
             },
+            onOpenEvent = { eventId -> selectedEventId = eventId },
             onOpenUserProfile = onOpenUserProfile,
             modifier = modifier,
             bottomBarPadding = bottomBarPadding
@@ -940,6 +949,7 @@ private fun ForumEventCard(
 fun ForumEventDetailContent(
     viewModel: ForumViewModel,
     onBack: () -> Unit,
+    onOpenCommunity: (String) -> Unit = {},
     onOpenUserProfile: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     bottomBarPadding: androidx.compose.ui.unit.Dp = 110.dp
@@ -1084,7 +1094,7 @@ fun ForumEventDetailContent(
                                     val community = event.communityId?.let { id -> communityById[id] }
                                     if (community != null) {
                                         AssistChip(
-                                            onClick = {},
+                                            onClick = { onOpenCommunity(community.id) },
                                             label = { Text(community.name, style = MaterialTheme.typography.labelSmall) },
                                             leadingIcon = {
                                                 CommunityAvatar(name = community.name, avatarUrl = community.avatarUrl, size = 16.dp)
@@ -1815,6 +1825,7 @@ fun CommunitiesContent(
     onCommunityClick: (String) -> Unit = {}
 ) {
     val state by viewModel.communitiesListState.collectAsState()
+    val communityEventsById by viewModel.communityEventsById.collectAsState()
 
     Column(modifier = modifier.fillMaxSize()) {
         OutlinedTextField(
@@ -1862,8 +1873,12 @@ fun CommunitiesContent(
                         verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         items(items = state.communities, key = { it.id }) { community ->
+                            LaunchedEffect(community.id) {
+                                viewModel.loadCommunityEvents(community.id)
+                            }
                             CommunityCard(
                                 community = community,
+                                eventsCount = communityEventsById[community.id]?.size ?: 0,
                                 onClick = { onCommunityClick(community.id) }
                             )
                         }
@@ -1879,6 +1894,7 @@ fun CommunitiesContent(
 @Composable
 fun CommunityCard(
     community: CommunityResponse,
+    eventsCount: Int = 0,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
@@ -1953,6 +1969,10 @@ fun CommunityCard(
                             Icon(Icons.Filled.Article, contentDescription = null, modifier = Modifier.size(12.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                             Text(text = "${community.postCount}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
+                        Row(horizontalArrangement = Arrangement.spacedBy(3.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Filled.Event, contentDescription = null, modifier = Modifier.size(12.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(text = "$eventsCount", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
                     }
                 }
             }
@@ -1992,12 +2012,16 @@ fun CommunityDetailScreen(
     communityId: String,
     viewModel: ForumViewModel,
     onBack: () -> Unit,
+    onOpenEvent: (String) -> Unit = {},
     onOpenUserProfile: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     bottomBarPadding: androidx.compose.ui.unit.Dp = 110.dp
 ) {
     val detailState by viewModel.communityDetailState.collectAsState()
     val createPostState by viewModel.createPostState.collectAsState()
+    val communityEventsById by viewModel.communityEventsById.collectAsState()
+    val communityEventsLoading by viewModel.communityEventsLoading.collectAsState()
+    val communityEventsErrorById by viewModel.communityEventsErrorById.collectAsState()
     var showNewPost by remember { mutableStateOf(false) }
     var showAllMembers by remember { mutableStateOf(false) }
     var selectedPost by remember { mutableStateOf<CommunityPostResponse?>(null) }
@@ -2005,6 +2029,9 @@ fun CommunityDetailScreen(
     val postSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val community = detailState.community
+    val communityEvents = communityEventsById[communityId].orEmpty()
+    val communityEventsLoadingForId = communityEventsLoading.contains(communityId)
+    val communityEventsError = communityEventsErrorById[communityId]
 
     Scaffold(
         topBar = {
@@ -2392,6 +2419,77 @@ fun CommunityDetailScreen(
                                 }
                             }
                         }
+                    }
+                }
+            }
+
+            // ── Events section ──
+            item {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    elevation = CardDefaults.cardElevation(2.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Icon(
+                                Icons.Filled.Event,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Text(
+                                text = "Events (${communityEvents.size})",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                        if (communityEventsLoadingForId && communityEvents.isEmpty()) {
+                            Box(modifier = Modifier.fillMaxWidth().height(56.dp), contentAlignment = Alignment.Center) {
+                                CircularProgressIndicator(modifier = Modifier.size(28.dp), color = MaterialTheme.colorScheme.primary)
+                            }
+                        } else if (communityEventsError != null && communityEvents.isEmpty()) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = communityEventsError,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                TextButton(onClick = { viewModel.loadCommunityEvents(communityId, forceRefresh = true) }) {
+                                    Text("Retry")
+                                }
+                            }
+                        } else if (communityEvents.isEmpty()) {
+                            Text(
+                                text = "No events yet for this community.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (communityEvents.isNotEmpty()) {
+                items(items = communityEvents, key = { it.id }) { event ->
+                    Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+                        ForumEventCard(
+                            event = event,
+                            community = community,
+                            onClick = { onOpenEvent(event.id) },
+                            onOpenUserProfile = onOpenUserProfile
+                        )
                     }
                 }
             }

--- a/app/app/src/main/java/com/hive/hive_app/ui/main/ForumViewModel.kt
+++ b/app/app/src/main/java/com/hive/hive_app/ui/main/ForumViewModel.kt
@@ -676,6 +676,12 @@ class ForumViewModel @Inject constructor(
 
     private val _communityById = MutableStateFlow<Map<String, CommunityResponse>>(emptyMap())
     val communityById: StateFlow<Map<String, CommunityResponse>> = _communityById.asStateFlow()
+    private val _communityEventsById = MutableStateFlow<Map<String, List<ForumEventResponse>>>(emptyMap())
+    val communityEventsById: StateFlow<Map<String, List<ForumEventResponse>>> = _communityEventsById.asStateFlow()
+    private val _communityEventsLoading = MutableStateFlow<Set<String>>(emptySet())
+    val communityEventsLoading: StateFlow<Set<String>> = _communityEventsLoading.asStateFlow()
+    private val _communityEventsErrorById = MutableStateFlow<Map<String, String?>>(emptyMap())
+    val communityEventsErrorById: StateFlow<Map<String, String?>> = _communityEventsErrorById.asStateFlow()
 
     fun setCommunitySearchQuery(query: String) {
         _communitiesListState.update { it.copy(searchQuery = query) }
@@ -1038,6 +1044,47 @@ class ForumViewModel @Inject constructor(
             communityRepository.getCommunity(id).onSuccess { community ->
                 updateCommunityCache(listOf(community))
             }
+        }
+    }
+
+    fun getCommunityEvents(communityId: String?): List<ForumEventResponse> {
+        val id = communityId?.trim().orEmpty()
+        if (id.isBlank()) return emptyList()
+        return _communityEventsById.value[id] ?: emptyList()
+    }
+
+    fun getCommunityEventCount(communityId: String?): Int = getCommunityEvents(communityId).size
+
+    fun getCommunityEventsError(communityId: String?): String? {
+        val id = communityId?.trim().orEmpty()
+        if (id.isBlank()) return null
+        return _communityEventsErrorById.value[id]
+    }
+
+    fun isCommunityEventsLoading(communityId: String?): Boolean {
+        val id = communityId?.trim().orEmpty()
+        if (id.isBlank()) return false
+        return _communityEventsLoading.value.contains(id)
+    }
+
+    fun loadCommunityEvents(communityId: String, forceRefresh: Boolean = false) {
+        val id = communityId.trim()
+        if (id.isBlank()) return
+        if (!forceRefresh && _communityEventsById.value.containsKey(id)) return
+        if (_communityEventsLoading.value.contains(id)) return
+        viewModelScope.launch {
+            _communityEventsLoading.update { it + id }
+            _communityEventsErrorById.update { it + (id to null) }
+            communityRepository.getCommunityEvents(id)
+                .onSuccess { response ->
+                    _communityEventsById.update { cache -> cache + (id to response.events) }
+                }
+                .onFailure { e ->
+                    _communityEventsErrorById.update { errors ->
+                        errors + (id to (e.message ?: "Failed to load community events"))
+                    }
+                }
+            _communityEventsLoading.update { it - id }
         }
     }
 

--- a/app/app/src/test/java/com/hive/hive_app/data/repository/CommunityRepositoryTest.kt
+++ b/app/app/src/test/java/com/hive/hive_app/data/repository/CommunityRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.hive.hive_app.data.api.dto.CommunityPostCreate
 import com.hive.hive_app.data.api.dto.CommunityPostListResponse
 import com.hive.hive_app.data.api.dto.CommunityPostResponse
 import com.hive.hive_app.data.api.dto.CommunityResponse
+import com.hive.hive_app.data.api.dto.ForumEventListResponse
 import com.hive.hive_app.data.api.dto.ForumUserEmbed
 import com.hive.hive_app.data.api.dto.UpvoteResponse
 import kotlinx.coroutines.runBlocking
@@ -129,6 +130,10 @@ class CommunityRepositoryTest {
             postId: String,
             pinned: Boolean
         ): Response<CommunityPostResponse> = unused()
+
+        override suspend fun getCommunityEvents(
+            communityId: String
+        ): Response<ForumEventListResponse> = unused()
 
         private fun <T> unused(): Response<T> {
             throw UnsupportedOperationException("Unused in this test")


### PR DESCRIPTION
## Description

This PR adds community events support to the mobile forum flow so users can see events related to a community and navigate between community and event details more smoothly.

## Test Plan

- Open the app and navigate to Forum → Communities.
- Verify each community card shows an event count.
- Open a community:
  - confirm events load and render under the new Events section,
  - verify empty-state text when no events exist,
  - verify error + Retry behavior (using network toggle or mocked failure).
- Tap an event in community detail and confirm event detail opens.
- From event detail, tap the community chip and confirm community detail opens.
- Run unit tests for repository/viewmodel paths impacted by community event loading.
- Confirm app version is `1.1.15` / `15`.